### PR TITLE
Update AsyncDatabase config handling

### DIFF
--- a/models/database.py
+++ b/models/database.py
@@ -34,7 +34,10 @@ class AsyncDatabase:
 
     async def get_connection(self):
         try:
-            conn = await aiomysql.connect(**self.config, autocommit=True)
+            cfg = self.config.copy()
+            if "database" in cfg:
+                cfg["db"] = cfg.pop("database")
+            conn = await aiomysql.connect(**cfg, autocommit=True)
             return conn
         except aiomysql.MySQLError as err:
             logger.error("Async DB connection error: %s", err)


### PR DESCRIPTION
## Summary
- adjust `AsyncDatabase.get_connection` to convert the `database` key to `db`
- keep existing configuration examples unchanged

## Testing
- `pylint models/database.py` *(fails: Unable to import mysql.connector and aiomysql)*

------
https://chatgpt.com/codex/tasks/task_e_684a41ee3d2883289c9b993ae02d104c