### PR TITLE
Fix skill menu deferral handling

### DIFF
--- a/game/battle_system.py
+++ b/game/battle_system.py
@@ -673,7 +673,13 @@ class BattleSystem(commands.Cog):
         for a in abilities:
             a["current_cooldown"] = cds.get(a["ability_id"], 0)
         
-        await interaction.response.defer()
+        try:
+            if not interaction.response.is_done():
+                await interaction.response.defer()
+        except discord.errors.HTTPException as e:
+            logger.debug(
+                "Deferred interaction failed (already acknowledged): %s", e
+            )
         await embed_mgr.send_skill_menu_embed(interaction, abilities)
 
     async def display_trance_menu(self, interaction: discord.Interaction) -> None:


### PR DESCRIPTION
## Summary
- avoid double acknowledgment when opening the skill menu by checking `interaction.response.is_done()`
- catch HTTPException when deferring and log a debug message

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a48d9cfe0832883b4b232ac39b15d