### PR TITLE
Add debug log for on_interaction

### DIFF
--- a/game/game_master.py
+++ b/game/game_master.py
@@ -1924,6 +1924,8 @@ class GameMaster(commands.Cog):
         if interaction.type != InteractionType.component:
             return
         cid = (interaction.data.get("custom_id") or "").strip()
+        logger.debug("[Game] on_interaction id=%s done=%s cid=%r",
+                     interaction.id, interaction.response.is_done(), cid)
         # ──────────────────────────────────────────────────────────────────
         # ignore our greyed‑out “⛔” placeholders
         if cid.endswith("_disabled"):


### PR DESCRIPTION
## Summary
- add debug statement to log interaction start details

## Testing
- `python -m py_compile game/game_master.py`


------
https://chatgpt.com/codex/tasks/task_e_684abc8f6794832886a786e472ae6592