### PR TITLE
Handle deferral for intro buttons

### DIFF
--- a/game/game_master.py
+++ b/game/game_master.py
@@ -2159,8 +2159,20 @@ class GameMaster(commands.Cog):
                 )
 
             if cid == "intro_continue":
+                if not interaction.response.is_done():
+                    defer_fn = getattr(interaction.response, "defer_update", None)
+                    if callable(defer_fn):
+                        await defer_fn()
+                    else:
+                        await interaction.response.defer()
                 return await self.begin_intro_sequence(interaction, interaction.channel.id)
             if cid == "intro_skip":
+                if not interaction.response.is_done():
+                    defer_fn = getattr(interaction.response, "defer_update", None)
+                    if callable(defer_fn):
+                        await defer_fn()
+                    else:
+                        await interaction.response.defer()
                 return await self.skip_intro(interaction, interaction.channel.id)
 
             if cid.startswith("action_shop_"):


### PR DESCRIPTION
## Summary
- defer interaction responses for intro_continue and intro_skip buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684abcb83f4883288cba850eaf74a146