### PR TITLE
Fix missing defer in start_session

### DIFF
--- a/game/game_master.py
+++ b/game/game_master.py
@@ -376,6 +376,12 @@ class GameMaster(commands.Cog):
     async def start_session(self,
                             interaction: discord.Interaction,
                             difficulty: str) -> None:
+        if not interaction.response.is_done():
+            defer_fn = getattr(interaction.response, "defer_update", None)
+            if callable(defer_fn):
+                await defer_fn()
+            else:
+                await interaction.response.defer()
         sm = self.bot.get_cog("SessionManager")
         session = sm.get_session(interaction.channel.id) if sm else None
         if not session:


### PR DESCRIPTION
## Summary
- defer interaction responses in `start_session` to mirror other handlers

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684abcc195908328bb55f1e56e69efdc