### PR TITLE
Fix start_game defer logic

### DIFF
--- a/game/game_master.py
+++ b/game/game_master.py
@@ -2099,6 +2099,13 @@ class GameMaster(commands.Cog):
                 return await self.end_player_turn(interaction)
 
             if cid == "start_game":
+                if not interaction.response.is_done():
+                    defer_fn = getattr(interaction.response, "defer_update", None)
+                    if callable(defer_fn):
+                        await defer_fn()
+                    else:
+                        await interaction.response.defer()
+
                 sm = self.bot.get_cog("SessionManager")
                 session = sm.get_session(interaction.channel.id) if sm else None
                 if not session:


### PR DESCRIPTION
## Summary
- ensure the `start_game` button handler defers the interaction before running game logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684abce09dc08328827734c8926f481f