### PR TITLE
Fix victory continue deferral

### DIFF
--- a/game/battle_system.py
+++ b/game/battle_system.py
@@ -1313,6 +1313,15 @@ class BattleSystem(commands.Cog):
         session = mgr.get_session(interaction.channel.id) if mgr else None
 
         if cid == "battle_victory_continue":
+            if not interaction.response.is_done():
+                try:
+                    await interaction.response.defer()
+                except discord.errors.HTTPException as e:
+                    logger.debug(
+                        "Deferred interaction failed (already acknowledged): %s",
+                        e,
+                    )
+
             if session:
                 conn = self.db_connect()
                 with conn.cursor(dictionary=True) as cur:

--- a/game/game_master.py
+++ b/game/game_master.py
@@ -1270,7 +1270,9 @@ class GameMaster(commands.Cog):
             try:
                 await interaction.response.defer()
             except discord.errors.HTTPException as e:
-                logger.debug("Deferred interaction failed: %s", e)
+                logger.debug(
+                    "Deferred interaction failed (already acknowledged): %s", e
+                )
 
         # Look up the saved flag
         from models.session_models import SessionModel

--- a/hub/hub_manager.py
+++ b/hub/hub_manager.py
@@ -263,6 +263,9 @@ class HubManager(commands.Cog):
                 embed=main_embed,
                 view=HubView()
             )
+        if cid == "setup_new_game":
+            # handled in GameMaster.on_interaction
+            return
 
         logger.debug(f"HubManager: unhandled custom_id='{cid}'")
 


### PR DESCRIPTION
## Summary
- defer interaction before processing `battle_victory_continue` so followup actions don't fail

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a467070988328856a0c2d3698fa24