### PR TITLE
Fix redundant defer call

### DIFF
--- a/game/game_master.py
+++ b/game/game_master.py
@@ -1582,6 +1582,12 @@ class GameMaster(commands.Cog):
                 "❌ No session.", ephemeral=True
             )
 
+        if not interaction.response.is_done():
+            try:
+                await interaction.response.defer()
+            except discord.errors.HTTPException as e:
+                logger.debug("Deferred interaction failed: %s", e)
+
         pd = next((
             p for p in
             SessionPlayerModel.get_player_states(session.session_id)
@@ -1697,6 +1703,12 @@ class GameMaster(commands.Cog):
         session = sm.get_session(interaction.channel.id) if sm else None
         if not session:
             return await interaction.response.send_message("❌ No session.", ephemeral=True)
+
+        if not interaction.response.is_done():
+            try:
+                await interaction.response.defer()
+            except discord.errors.HTTPException as e:
+                logger.debug("Deferred interaction failed: %s", e)
 
         # pull current player data
         pd = next(p for p in SessionPlayerModel.get_player_states(session.session_id)
@@ -1950,7 +1962,11 @@ class GameMaster(commands.Cog):
         # New Game button in hub → create session
         if cid == "setup_new_game":
             # ACK the button silently (no ephemeral, no new message)
-            await interaction.response.defer()
+            if not interaction.response.is_done():
+                try:
+                    await interaction.response.defer()
+                except discord.errors.HTTPException as e:
+                    logger.debug("Deferred interaction failed: %s", e)
             await self.create_session(interaction, max_slots=6)
             return
         # ─── “End My Turn” on death (multiplayer) ───────────────────


### PR DESCRIPTION
## Summary
- avoid calling `interaction.response.defer()` if already done when setting up new games
- defer when showing character sheet or class abilities to prevent failures

## Testing
- `python -m pip install pylint`
- `python -m pylint $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684ac02ce9f8832885e616a6c8f54689