### PR TITLE
Ensure DB player added when joining sessions

### DIFF
--- a/game/session_manager.py
+++ b/game/session_manager.py
@@ -211,9 +211,13 @@ class SessionManager(commands.Cog):
             return await interaction.response.send_message(
                 "⚠️ You’ve already joined this session!", ephemeral=True
             )
+
         try:
-                session.add_player(user.id)
+                SessionPlayerModel.add_player(
+                    session_id, user.id, user.display_name
+                )
                 SessionModel.increment_player_count(session_id)
+                session.add_player(user.id)
                 session.players = SessionPlayerModel.get_players(session_id)
                 logger.info("User %s added to session %s.", user.id, session_id)
 


### PR DESCRIPTION
## Summary
- update `join_session` so the new player is inserted into `session_players` before the session's player count is incremented
- keep in-memory player list in sync

## Testing
- `pylint $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c27cdb19c832885727959d8616b06