### PR TITLE
Fix high score field names

### DIFF
--- a/hub/hub_embed.py
+++ b/hub/hub_embed.py
@@ -128,7 +128,11 @@ def get_high_scores_embed(high_scores_data):
         for entry in high_scores_data:
             embed.add_field(
                 name=f"{entry.get('player_name', 'Unknown')} ({entry.get('player_class', 'N/A')})",
-                value=f"Rooms: {entry.get('rooms', 'N/A')}\nEnemies: {entry.get('enemies', 'N/A')}\nGil: {entry.get('gil', 'N/A')}",
+                value=(
+                    f"Rooms: {entry.get('rooms_visited', 'N/A')}\n"
+                    f"Enemies: {entry.get('enemies_defeated', 'N/A')}\n"
+                    f"Gil: {entry.get('gil', 'N/A')}"
+                ),
                 inline=False
             )
     embed.set_footer(text="Press 'Back' to return to the main menu.")


### PR DESCRIPTION
## Summary
- use rooms_visited and enemies_defeated columns in the high scores embed

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685008e70b008328b10f71ff05511e55