### PR TITLE
Update high score embed with new stats

### DIFF
--- a/database/database_setup.py
+++ b/database/database_setup.py
@@ -841,6 +841,8 @@ TABLES = {
             player_class     VARCHAR(50),
             gil              INT DEFAULT 0,
             enemies_defeated INT DEFAULT 0,
+            rooms_visited    INT DEFAULT 0,
+            difficulty       VARCHAR(50),
             play_time        INT DEFAULT 0,
             completed_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )

--- a/hub/hub_embed.py
+++ b/hub/hub_embed.py
@@ -131,7 +131,8 @@ def get_high_scores_embed(high_scores_data):
                 value=(
                     f"Rooms: {entry.get('rooms_visited', 'N/A')}\n"
                     f"Enemies: {entry.get('enemies_defeated', 'N/A')}\n"
-                    f"Gil: {entry.get('gil', 'N/A')}"
+                    f"Gil: {entry.get('gil', 'N/A')}\n"
+                    f"Difficulty: {entry.get('difficulty', 'N/A')}"
                 ),
                 inline=False
             )


### PR DESCRIPTION
## Summary
- include rooms visited and difficulty in high score embed
- extend `high_scores` table with columns for rooms visited and difficulty

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68500c7fcd2c83289ac0f773bcde915b