### PR TITLE
Fix high score room count

### DIFF
--- a/game/session_manager.py
+++ b/game/session_manager.py
@@ -280,7 +280,7 @@ class SessionManager(commands.Cog):
             cur.execute(
                 """
                 SELECT p.username, p.level, p.gil, p.discovered_rooms,
-                       p.enemies_defeated, c.class_name
+                       p.enemies_defeated, p.rooms_visited, c.class_name
                   FROM players p
              LEFT JOIN classes c ON p.class_id = c.class_id
                  WHERE p.session_id = %s
@@ -294,10 +294,7 @@ class SessionManager(commands.Cog):
                 play_time = int((datetime.utcnow() - sess["created_at"]).total_seconds())
 
             for p in players:
-                try:
-                    rooms = len(json.loads(p.get("discovered_rooms") or "[]"))
-                except Exception:
-                    rooms = 0
+                rooms = p.get("rooms_visited", 0)
 
                 data = {
                     "player_name": p.get("username"),


### PR DESCRIPTION
## Summary
- read rooms_visited directly when recording high scores
- include rooms_visited in the player stats query

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850b648f1288328a8b301b2122f973b