### PR TITLE
Add rooms_visited sorting option

### DIFF
--- a/game/high_score.py
+++ b/game/high_score.py
@@ -71,7 +71,13 @@ def fetch_scores(limit: int = 20, sort_by: str = "play_time") -> List[Dict[str, 
     list[dict]
         List of score rows. Returns an empty list if any error occurs.
     """
-    valid_columns = {"play_time", "enemies_defeated", "gil", "player_level"}
+    valid_columns = {
+        "play_time",
+        "enemies_defeated",
+        "gil",
+        "player_level",
+        "rooms_visited",
+    }
     order_clause = "play_time ASC, enemies_defeated DESC"
     if sort_by in valid_columns and sort_by != "play_time":
         order_clause = f"{sort_by} DESC"

--- a/hub/hub_embed.py
+++ b/hub/hub_embed.py
@@ -119,6 +119,7 @@ def get_high_scores_embed(high_scores_data, sort_by: str = "play_time"):
         "enemies_defeated": "Enemies Defeated",
         "gil": "Gil",
         "player_level": "Level",
+        "rooms_visited": "Rooms Visited",
     }
     sort_label = sort_labels.get(sort_by, sort_by)
 

--- a/hub/hub_manager.py
+++ b/hub/hub_manager.py
@@ -298,6 +298,7 @@ class SortSelect(discord.ui.Select):
         options = [
             discord.SelectOption(label="Play Time", value="play_time"),
             discord.SelectOption(label="Enemies Defeated", value="enemies_defeated"),
+            discord.SelectOption(label="Rooms Visited", value="rooms_visited"),
             discord.SelectOption(label="Gil", value="gil"),
             discord.SelectOption(label="Level", value="player_level"),
         ]

--- a/tests/test_high_score.py
+++ b/tests/test_high_score.py
@@ -99,3 +99,32 @@ def test_record_score_prunes_to_20(monkeypatch):
     names = [s["player_name"] for s in scores]
     assert len(names) == 20
     assert "Worst" not in names
+
+
+def test_fetch_scores_rooms_visited_sort(monkeypatch):
+    conn = FakeConnection()
+
+    def fake_get_connection(self):
+        return conn
+
+    monkeypatch.setattr(Database, "get_connection", fake_get_connection)
+
+    base = {
+        "player_name": "P",
+        "guild_id": 1,
+        "player_level": 1,
+        "player_class": "Mage",
+        "gil": 0,
+        "enemies_defeated": 0,
+    }
+
+    for i in range(5):
+        data = base.copy()
+        data["player_name"] = f"P{i}"
+        data["play_time"] = i
+        data["rooms_visited"] = i
+        assert high_score.record_score(data)
+
+    scores = high_score.fetch_scores(limit=5, sort_by="rooms_visited")
+    rooms_list = [s["rooms_visited"] for s in scores]
+    assert rooms_list == sorted(rooms_list, reverse=True)


### PR DESCRIPTION
## Summary
- enable `rooms_visited` sorting in `fetch_scores`
- expose "Rooms Visited" in high score sorting dropdown
- reflect new sort option in high score embed label
- test descending order of `rooms_visited`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850b65bcfb08328aad4786bc62c0da2