### PR TITLE
Fix gil tracking deadlock

### DIFF
--- a/game/battle_system.py
+++ b/game/battle_system.py
@@ -1290,9 +1290,9 @@ class BattleSystem(commands.Cog):
                 "UPDATE players SET gil = %s, inventory = %s WHERE player_id = %s AND session_id = %s",
                 (new_gil, json.dumps(inv), pid, sid),
             )
+            conn.commit()
             if gil:
                 SessionPlayerModel.add_gil_earned(sid, pid, gil)
-            conn.commit()
 
         cursor.close(); conn.close()
         return "\n".join(lines) if lines else "No rewards."

--- a/game/inventory_shop.py
+++ b/game/inventory_shop.py
@@ -602,6 +602,7 @@ class InventoryShop(commands.Cog):
                 (player["gil"] + sell_price, json.dumps(inv_dict),
                  interaction.user.id, session.session_id)
             )
+            conn.commit()
             SessionPlayerModel.add_gil_earned(session.session_id, interaction.user.id, sell_price)
             cur.execute(
                 """

--- a/game/treasure_chest.py
+++ b/game/treasure_chest.py
@@ -93,9 +93,9 @@ def _apply_chest_rewards(
                 "UPDATE players SET gil=%s, inventory=%s WHERE player_id=%s AND session_id=%s",
                 (gil, json.dumps(inv), player_id, session_id),
             )
+            conn.commit()
             if gil:
                 SessionPlayerModel.add_gil_earned(session_id, player_id, gil)
-        conn.commit()
     finally:
         conn.close()
 


### PR DESCRIPTION
## Summary
- avoid DB lock waits by committing before calling `add_gil_earned`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mysql')*

------
https://chatgpt.com/codex/tasks/task_e_684d76024a8c8328add9fd89b8bdc716