### PR TITLE
Fix interaction acknowledgment on menu back

### DIFF
--- a/game/session_manager.py
+++ b/game/session_manager.py
@@ -451,6 +451,12 @@ class SessionManager(commands.Cog):
 
 
     async def return_to_current_view(self, interaction: discord.Interaction) -> None:
+        try:
+            if not interaction.response.is_done():
+                await interaction.response.defer()
+        except discord.errors.HTTPException as e:
+            logger.debug("Deferred interaction failed: %s", e)
+
         session = self.get_session(interaction.channel.id)
         if not session:
             if not interaction.response.is_done():


### PR DESCRIPTION
## Summary
- defer Discord interaction before returning to the current game view

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850d983939c8328bbc333b6bc7445ab