### PR TITLE
Remove play_time column

### DIFF
--- a/database/database_setup.py
+++ b/database/database_setup.py
@@ -844,7 +844,6 @@ TABLES = {
             bosses_defeated INT DEFAULT 0,
             rooms_visited    INT DEFAULT 0,
             score_value      INT DEFAULT 0,
-            play_time        INT DEFAULT 0,
             difficulty       VARCHAR(50),
             completed_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )

--- a/game/session_manager.py
+++ b/game/session_manager.py
@@ -5,7 +5,6 @@ from typing import Optional, Tuple, Dict, List, Any
 import mysql.connector
 import json
 import asyncio
-from datetime import datetime
 
 from game import high_score
 
@@ -289,9 +288,6 @@ class SessionManager(commands.Cog):
             )
             players = cur.fetchall() or []
 
-            play_time = 0
-            if sess.get("created_at"):
-                play_time = int((datetime.utcnow() - sess["created_at"]).total_seconds())
 
             for p in players:
                 rooms = p.get("rooms_visited", 0)
@@ -308,7 +304,6 @@ class SessionManager(commands.Cog):
                     "enemies_defeated": enemies,
                     "bosses_defeated": bosses,
                     "rooms_visited": rooms,
-                    "play_time": play_time,
                     "score_value": score_val,
                     "difficulty": sess.get("difficulty"),
                 }
@@ -353,9 +348,6 @@ class SessionManager(commands.Cog):
             if not p:
                 return False
 
-            play_time = 0
-            if sess.get("created_at"):
-                play_time = int((datetime.utcnow() - sess["created_at"]).total_seconds())
 
             rooms = p.get("rooms_visited", 0)
             enemies = p.get("enemies_defeated", 0)
@@ -371,7 +363,6 @@ class SessionManager(commands.Cog):
                 "enemies_defeated": enemies,
                 "bosses_defeated": bosses,
                 "rooms_visited": rooms,
-                "play_time": play_time,
                 "score_value": score_val,
                 "difficulty": sess.get("difficulty"),
             }

--- a/models/hub_model.py
+++ b/models/hub_model.py
@@ -59,20 +59,28 @@ class HubModel:
             conn.close()
 
     @staticmethod
-    def get_high_scores():
-        """
-        Retrieves the top 10 high scores from the 'high_scores' table,
-        ordered primarily by play_time ascending and then enemies_defeated descending.
-        Returns a list of dictionaries.
-        """
+    def get_high_scores(limit: int = 10, sort_by: str = "score_value"):
+        """Retrieve high score rows ordered by the given stat."""
         db = Database()
         conn = db.get_connection()
         cursor = conn.cursor(dictionary=True)
+        valid_columns = {
+            "score_value",
+            "enemies_defeated",
+            "bosses_defeated",
+            "gil",
+            "player_level",
+            "rooms_visited",
+        }
+        order_clause = "score_value DESC"
+        if sort_by in valid_columns and sort_by != "score_value":
+            order_clause = f"{sort_by} DESC"
         try:
-            sql = "SELECT * FROM high_scores ORDER BY play_time ASC, enemies_defeated DESC LIMIT 10"
-            cursor.execute(sql)
-            scores = cursor.fetchall()
-            return scores
+            cursor.execute(
+                f"SELECT * FROM high_scores ORDER BY {order_clause} LIMIT %s",
+                (limit,),
+            )
+            return cursor.fetchall()
         except Exception as e:
             logger.error("Error retrieving high scores: %s", e, exc_info=True)
             return []


### PR DESCRIPTION
## Summary
- drop play_time column from database setup
- stop tracking play_time in SessionManager score recording
- sort hub high scores by score_value

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685187fb041c832893a9a655e694d1a9