### PR TITLE
Implement high score confirmation flow

### DIFF
--- a/core/game_session.py
+++ b/core/game_session.py
@@ -75,6 +75,9 @@ class GameSession:
         # ── status effects ───────────────────────────────────────────────
         # { player_id: [ { "effect_id": int, "remaining": int }, … ] }
         self.status_effects: Dict[int, List[Dict[str, Any]]] = {}
+        # ── pending high score data ──────────────────────────────────────
+        # { player_id: {"data": {...}, "message_id": int} }
+        self.pending_high_score: Dict[int, Dict[str, Any]] = {}
 
     def add_player(self, player_id: int) -> None:
         """Add a player to the session.

--- a/hub/hub_embed.py
+++ b/hub/hub_embed.py
@@ -148,3 +148,25 @@ def get_high_scores_embed(high_scores_data, sort_by: str = "score_value"):
         text=f"Sorted by {sort_label}. Press 'Back' to return to the main menu."
     )
     return embed
+
+
+def get_high_score_prompt_embed(data: dict) -> discord.Embed:
+    """Return an embed summarising a player's stats for confirmation."""
+    embed = discord.Embed(
+        title="New High Score!",
+        description="Record your stats on the leaderboard?",
+        color=discord.Color.gold(),
+    )
+    embed.add_field(
+        name=f"{data.get('player_name')} ({data.get('player_class')})",
+        value=(
+            f"Score: {data.get('score_value')}\n"
+            f"Bosses: {data.get('bosses_defeated')}\n"
+            f"Enemies: {data.get('enemies_defeated')}\n"
+            f"Rooms: {data.get('rooms_visited')}\n"
+            f"Gil: {data.get('gil')}"
+        ),
+        inline=False,
+    )
+    embed.set_footer(text="Submit this score to the top 20?")
+    return embed

--- a/tests/test_high_score.py
+++ b/tests/test_high_score.py
@@ -7,6 +7,34 @@ import pytest
 sys.modules.setdefault("mysql", types.ModuleType("mysql"))
 sys.modules.setdefault("mysql.connector", types.ModuleType("connector"))
 sys.modules.setdefault("aiomysql", types.ModuleType("aiomysql"))
+sys.modules["mysql"].connector = sys.modules["mysql.connector"]
+sys.modules["mysql.connector"].connection = types.SimpleNamespace(MySQLConnection=object)
+sys.modules.setdefault("discord", types.ModuleType("discord"))
+sys.modules.setdefault("discord.ext", types.ModuleType("ext"))
+ext_mod = sys.modules["discord.ext"]
+ext_mod.commands = types.ModuleType("commands")
+sys.modules["discord.ext.commands"] = ext_mod.commands
+ext_mod.commands.Cog = object
+ext_mod.commands.Bot = object
+ext_mod.commands.command = lambda *a, **k: (lambda f: f)
+ext_mod.commands.has_guild_permissions = lambda **k: (lambda f: f)
+ext_mod.commands.Context = object
+
+discord = sys.modules["discord"]
+discord.InteractionType = types.SimpleNamespace(component=1)
+discord.ui = types.SimpleNamespace(View=object, Button=object)
+discord.ui.button = lambda *a, **k: (lambda f: f)
+discord.ButtonStyle = types.SimpleNamespace(primary=1, secondary=2, success=3, danger=4, blurple=5)
+discord.Color = types.SimpleNamespace(gold=lambda: None, blue=lambda: None, purple=lambda: None, green=lambda: None)
+discord.Interaction = type("Interaction", (), {})
+discord.Thread = type("Thread", (), {})
+discord.Member = type("Member", (), {})
+discord.Guild = type("Guild", (), {})
+discord.Message = type("Message", (), {})
+discord.TextChannel = type("TextChannel", (), {})
+discord.ChannelType = types.SimpleNamespace(private_thread=1)
+discord.Embed = type("Embed", (), {"__init__": lambda self, **k: None, "add_field": lambda *a, **k: None, "set_footer": lambda *a, **k: None, "set_image": lambda *a, **k: None})
+
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -62,11 +90,32 @@ class FakeCursor:
                 rev = direction.upper() == 'DESC'
                 sorted_rows = sorted(rows, key=lambda r: r[col], reverse=rev)
             self.result = [r.copy() for r in sorted_rows[:limit]]
+        elif sql.startswith("SELECT guild_id, difficulty, created_at FROM sessions"):
+            sid = params[0]
+            for r in self.conn.sessions:
+                if r["session_id"] == sid:
+                    self.result = r.copy()
+                    break
+            else:
+                self.result = None
+        elif sql.strip().startswith("SELECT p.username"):
+            sid, pid = params
+            for r in self.conn.players:
+                if r["session_id"] == sid and r["player_id"] == pid:
+                    self.result = r.copy()
+                    break
+            else:
+                self.result = None
         else:
             raise ValueError(f"Unhandled SQL: {sql}")
 
     def fetchall(self):
         return self.result or []
+
+    def fetchone(self):
+        if isinstance(self.result, list):
+            return self.result[0] if self.result else None
+        return self.result
 
     def close(self):
         pass
@@ -74,6 +123,8 @@ class FakeCursor:
 class FakeConnection:
     def __init__(self):
         self.rows = []
+        self.sessions = []
+        self.players = []
 
     def cursor(self, dictionary=False):
         return FakeCursor(self, dictionary)
@@ -195,3 +246,108 @@ def test_per_guild_pruning_and_fetch(monkeypatch):
     assert all(r["guild_id"] == 1 for r in g1_scores)
     assert all(r["guild_id"] == 2 for r in g2_scores)
     assert all(r["player_name"] != "Low" for r in g1_scores)
+
+
+def test_compute_score_and_qualification(monkeypatch):
+    conn = FakeConnection()
+
+    def fake_get_connection(self):
+        return conn
+
+    monkeypatch.setattr(Database, "get_connection", fake_get_connection)
+
+    conn.sessions.append({
+        "session_id": 1,
+        "guild_id": 1,
+        "difficulty": "Easy",
+        "created_at": "2025",
+    })
+    conn.players.append({
+        "session_id": 1,
+        "player_id": 10,
+        "username": "Hero",
+        "level": 2,
+        "gil": 50,
+        "enemies_defeated": 2,
+        "bosses_defeated": 1,
+        "rooms_visited": 5,
+        "class_name": "Warrior",
+    })
+
+    base = {
+        "player_name": "X",
+        "guild_id": 1,
+        "player_level": 1,
+        "player_class": "Mage",
+        "gil": 0,
+        "enemies_defeated": 0,
+        "bosses_defeated": 0,
+        "score_value": 0,
+    }
+    for i in range(5):
+        d = base.copy()
+        d["player_name"] = f"P{i}"
+        d["score_value"] = i
+        assert high_score.record_score(d)
+
+    from game.session_manager import SessionManager
+
+    sm = SessionManager(None)
+    sm.db_connect = lambda: conn
+
+    data = sm.compute_player_score_data(1, 10)
+    assert data["score_value"] == 2 + 1 * 5 + 5
+
+    top = high_score.fetch_scores(guild_id=1)
+    qualifies = len(top) < 20 or data["score_value"] >= top[-1]["score_value"]
+    assert qualifies
+
+
+class FakeResp:
+    def __init__(self):
+        self._done = False
+
+    def is_done(self):
+        return self._done
+
+    async def send_message(self, *args, **kwargs):
+        self._done = True
+
+
+def test_high_score_yes_no_flow(monkeypatch):
+    conn = FakeConnection()
+
+    def fake_get_connection(self):
+        return conn
+
+    monkeypatch.setattr(Database, "get_connection", fake_get_connection)
+
+    from core.game_session import GameSession
+
+    session = GameSession(1, 1, "123", 1)
+
+    data = {
+        "player_name": "Hero",
+        "player_class": "Warrior",
+        "gil": 0,
+        "enemies_defeated": 1,
+        "bosses_defeated": 0,
+        "rooms_visited": 2,
+        "score_value": 3,
+        "guild_id": 1,
+        "player_level": 1,
+        "difficulty": "Easy",
+    }
+
+    session.pending_high_score[42] = {"data": data}
+
+    # Simulate "Yes"
+    assert high_score.record_score(session.pending_high_score[42]["data"])
+    session.pending_high_score.pop(42, None)
+    assert len(conn.rows) == 1
+    assert 42 not in session.pending_high_score
+
+    # Simulate "No"
+    session.pending_high_score[42] = {"data": data}
+    session.pending_high_score.pop(42, None)
+    assert len(conn.rows) == 1


### PR DESCRIPTION
## Summary
- compute score stats in SessionManager
- store pending high score data in GameSession
- add HighScoreConfirmView and prompt embed
- handle confirmation flow in GameMaster
- expand high score tests for qualification and yes/no logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68519125b25c8328928cbfc59e5cc053