### PR TITLE
Ensure unique boss room

### DIFF
--- a/database/database_setup.py
+++ b/database/database_setup.py
@@ -270,6 +270,10 @@ MERGED_FLOOR_ROOM_RULES: List[Tuple[str, int, str, float, int]] = [
     ("Easy",  1, "item",           0.10,  5),
     ("Easy",  1, "locked",         0.05,  2),
     ("Easy",  1, "staircase_up",   0.05,  1),
+    ("Easy",  None, "boss",        0.0,   1),
+    ("Medium", None, "boss",       0.0,   1),
+    ("Hard",  None, "boss",        0.0,   1),
+    ("Crazy Catto", None, "boss",  0.0,   1),
     # …etc for each floor / difficulty…
 ]
 

--- a/game/dungeon_generator.py
+++ b/game/dungeon_generator.py
@@ -601,6 +601,7 @@ class DungeonGenerator(commands.Cog):
                 for rt, cap in remaining.items()
                 if cap > 0
                 and rt not in ("staircase_up", "staircase_down")
+                and not (boss_coord is not None and rt == "boss")
                 and not (exclude_locked and rt == "locked")
                 and not (exclude_item and rt == "item")
                 and not (exclude_shop and rt == "shop")

--- a/tests/test_dungeon_generator.py
+++ b/tests/test_dungeon_generator.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import types
+import random
+
+# Stub mysql and discord modules similar to test_high_score
+sys.modules.setdefault("mysql", types.ModuleType("mysql"))
+sys.modules.setdefault("mysql.connector", types.ModuleType("connector"))
+sys.modules.setdefault("aiomysql", types.ModuleType("aiomysql"))
+sys.modules["mysql"].connector = sys.modules["mysql.connector"]
+sys.modules["mysql.connector"].connection = types.SimpleNamespace(MySQLConnection=object)
+sys.modules.setdefault("discord", types.ModuleType("discord"))
+sys.modules.setdefault("discord.ext", types.ModuleType("ext"))
+ext_mod = sys.modules["discord.ext"]
+ext_mod.commands = types.ModuleType("commands")
+sys.modules["discord.ext.commands"] = ext_mod.commands
+ext_mod.commands.Cog = object
+ext_mod.commands.Bot = object
+ext_mod.commands.command = lambda *a, **k: (lambda f: f)
+ext_mod.commands.has_guild_permissions = lambda **k: (lambda f: f)
+ext_mod.commands.has_permissions = lambda **k: (lambda f: f)
+ext_mod.commands.Context = object
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from game.dungeon_generator import DungeonGenerator
+
+
+def test_single_boss_room(monkeypatch):
+    gen = DungeonGenerator(None)
+    monkeypatch.setattr(gen, "fetch_floor_rules", lambda d, f: [])
+    random.seed(42)
+    rooms, _ = gen.generate_rooms_for_floor(
+        1, 4, 4, 4, 0.5, 0, 0, True, 0, 0, 3, 3, "Easy", 1
+    )
+    boss_cells = [r for r in rooms if r[3] == "boss"]
+    assert len(boss_cells) == 1
+


### PR DESCRIPTION
## Summary
- exclude `boss` from random room type choice once the boss coordinate is fixed
- define a single boss rule for each difficulty
- add regression test verifying only one boss room is created

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851a5c7fe008328ad698f19880f6f7d