### PR TITLE
Add randomized illusion challenges

### DIFF
--- a/database/database_setup.py
+++ b/database/database_setup.py
@@ -170,7 +170,10 @@ MERGED_ROOM_TEMPLATES: List[Tuple] = [
     (15, 'shop',          'Shop Room',          'A traveling moogle is seen hiding...',                                                            'https://the-demiurge.com/DemiDevUnit/images/shop/stiltzkin.gif',                None,'2025-03-30 21:40:47'),
     (16, 'illusion',      'Illusion Chamber',   'The room shimmers mysteriously...',                                                               'https://the-demiurge.com/DemiDevUnit/images/rooms/roomtypeillusion.png',        None,'2025-03-30 21:40:47'),
     (17, 'locked',        'Locked Door',        'A heavy locked door. You need a key.',                                                            'https://the-demiurge.com/DemiDevUnit/images/rooms/locked.png',                  None,'2025-04-19 13:55:00'),
-    (18, 'chest_unlocked','Unlocked Chest',     'The chest lies open, its contents revealed.', 'https://your.cdn/path/chest_unlocked.png', None, '2025-04-23 18:00:00')
+    (18, 'chest_unlocked','Unlocked Chest',     'The chest lies open, its contents revealed.', 'https://your.cdn/path/chest_unlocked.png', None, '2025-04-23 18:00:00'),
+    (19, 'illusion_enemy_count', 'Illusion Chamber', 'Shifting shadows form the shapes of countless foes.', 'https://the-demiurge.com/DemiDevUnit/images/rooms/roomtypeillusion.png', None, '2025-04-24 12:00:00'),
+    (20, 'illusion_inner_room',  'Illusion Chamber', 'Several doors materialise from thin air, each beckoning.', 'https://the-demiurge.com/DemiDevUnit/images/rooms/roomtypeillusion.png', None, '2025-04-24 12:00:00'),
+    (21, 'illusion_elemental',  'Illusion Chamber', 'Glowing elemental crystals illuminate the chamber.', 'https://the-demiurge.com/DemiDevUnit/images/rooms/roomtypeillusion.png', None, '2025-04-24 12:00:00')
 ]
 
 # --- items --------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- introduce `fetch_discovered_rooms` helper
- randomize illusion challenge type and store the answer
- warp player away on failure
- seed DB with additional illusion room templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851b099b7dc8328b0dd7404cbb75336