### PR TITLE
Elemental resistance multipliers

### DIFF
--- a/database/database_setup.py
+++ b/database/database_setup.py
@@ -213,7 +213,9 @@ MERGED_ENEMY_DROPS: List[Tuple] = [
 
 # --- enemy resistances --------------------------------------------------------
 MERGED_ENEMY_RESISTANCES: List[Tuple] = [
-    (1, 1, 0)
+    (1, 1, 'weak', 1.5),
+    (2, 3, 'absorb', -1.0),
+    (3, 2, 'resist', 0.5)
 ]
 
 # --- levels -------------------------------------------------------------------
@@ -797,11 +799,12 @@ TABLES = {
     # ---------- enemy_resistances ----------
     'enemy_resistances': '''
         CREATE TABLE IF NOT EXISTS enemy_resistances (
-            enemy_id  INT NOT NULL,
+            enemy_id   INT NOT NULL,
             element_id INT NOT NULL,
-            resistance INT NOT NULL,
+            relation   ENUM('weak','resist','absorb','immune','normal') NOT NULL DEFAULT 'normal',
+            multiplier FLOAT NOT NULL DEFAULT 1.0,
             PRIMARY KEY (enemy_id, element_id),
-            FOREIGN KEY (enemy_id) REFERENCES enemies(enemy_id)   ON DELETE CASCADE,
+            FOREIGN KEY (enemy_id)  REFERENCES enemies(enemy_id)   ON DELETE CASCADE,
             FOREIGN KEY (element_id) REFERENCES elements(element_id) ON DELETE CASCADE
         )
     ''',
@@ -1127,7 +1130,7 @@ def insert_enemy_resistances(cur):
         logger.info("enemy_resistances already populated – skipping")
         return
     cur.executemany(
-        "INSERT INTO enemy_resistances (enemy_id,element_id,resistance) VALUES (%s,%s,%s)",
+        "INSERT INTO enemy_resistances (enemy_id,element_id,relation,multiplier) VALUES (%s,%s,%s,%s)",
         MERGED_ENEMY_RESISTANCES
     )
     logger.info("Inserted enemy_resistances.")

--- a/tests/test_ability_engine.py
+++ b/tests/test_ability_engine.py
@@ -1,0 +1,74 @@
+import json
+import os
+import sys
+import types
+
+# Stub mysql & discord modules like other tests
+sys.modules.setdefault("mysql", types.ModuleType("mysql"))
+sys.modules.setdefault("mysql.connector", types.ModuleType("connector"))
+sys.modules.setdefault("aiomysql", types.ModuleType("aiomysql"))
+sys.modules["mysql"].connector = sys.modules["mysql.connector"]
+sys.modules["mysql.connector"].connection = types.SimpleNamespace(MySQLConnection=object)
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utils.ability_engine import AbilityEngine
+
+class FakeCursor:
+    def __init__(self, rows):
+        self.rows = rows
+        self.result = None
+    def execute(self, sql, params=None):
+        for r in self.rows:
+            if r["enemy_id"] == params[0] and r["element_id"] == params[1]:
+                self.result = {"multiplier": r["multiplier"]}
+                break
+        else:
+            self.result = None
+    def fetchone(self):
+        return self.result
+    def close(self):
+        pass
+
+class FakeConnection:
+    def __init__(self, rows):
+        self.rows = rows
+    def cursor(self, dictionary=False):
+        return FakeCursor(self.rows)
+    def close(self):
+        pass
+
+
+def make_engine(rows, monkeypatch):
+    engine = AbilityEngine(lambda: FakeConnection(rows), damage_variance=0)
+    monkeypatch.setattr(AbilityEngine, "_attach_table_status_effects", lambda self, r, a: r)
+    monkeypatch.setattr(AbilityEngine, "_enrich_status_effects", lambda self, r: r)
+    return engine
+
+
+def base_entities():
+    user = {"attack_power": 10, "hp": 50, "max_hp": 50}
+    enemy = {"enemy_id": 1, "defense": 0, "hp": 50, "max_hp": 50}
+    ability = {"ability_name": "Test", "effect": json.dumps({"base_damage": 0}), "element_id": 1}
+    return user, enemy, ability
+
+
+def test_resistance_multiplier(monkeypatch):
+    engine = make_engine([{"enemy_id": 1, "element_id": 1, "multiplier": 0.5}], monkeypatch)
+    user, enemy, ability = base_entities()
+    result = engine.resolve(user, enemy, ability)
+    assert result.amount == 5
+
+
+def test_weakness_multiplier(monkeypatch):
+    engine = make_engine([{"enemy_id": 1, "element_id": 1, "multiplier": 1.5}], monkeypatch)
+    user, enemy, ability = base_entities()
+    result = engine.resolve(user, enemy, ability)
+    assert result.amount == 15
+
+
+def test_absorb_multiplier(monkeypatch):
+    engine = make_engine([{"enemy_id": 1, "element_id": 1, "multiplier": -1}], monkeypatch)
+    user, enemy, ability = base_entities()
+    result = engine.resolve(user, enemy, ability)
+    assert result.amount == -10


### PR DESCRIPTION
## Summary
- expand `enemy_resistances` table with relation and multiplier columns
- seed some elemental relationships
- expose `fetch_enemy_resistance` helper in `AbilityEngine`
- apply elemental multipliers during damage resolution
- add unit tests covering elemental damage multipliers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851cf8c3acc8328a55f3a1d22c4c21d