### PR TITLE
Fix flee mechanic restoring wrong coordinates

### DIFF
--- a/game/battle_system.py
+++ b/game/battle_system.py
@@ -1361,7 +1361,7 @@ class BattleSystem(commands.Cog):
         session.clear_battle_state()
 
         if prev:
-            px, py, pfloor = prev
+            pfloor, px, py = prev
             conn = self.db_connect()
             with conn.cursor() as cur:
                 cur.execute(


### PR DESCRIPTION
## Summary
- fix player coordinate restoration when fleeing a battle

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851d77764388328b4a3171c0f7e4961