### PR TITLE
Add crystal templates and illusion handling

### DIFF
--- a/database/database_setup.py
+++ b/database/database_setup.py
@@ -174,7 +174,8 @@ MERGED_ROOM_TEMPLATES: List[Tuple] = [
     (18, 'chest_unlocked','Unlocked Chest',     'The chest lies open, its contents revealed.', 'https://your.cdn/path/chest_unlocked.png', None, '2025-04-23 18:00:00'),
     (19, 'illusion_enemy_count', 'Illusion Chamber', 'Shifting shadows form the shapes of countless foes.', 'https://the-demiurge.com/DemiDevUnit/images/rooms/roomtypeillusion.png', None, '2025-04-24 12:00:00'),
     (20, 'illusion_inner_room',  'Illusion Chamber', 'Several doors materialise from thin air, each beckoning.', 'https://the-demiurge.com/DemiDevUnit/images/rooms/roomtypeillusion.png', None, '2025-04-24 12:00:00'),
-    (21, 'illusion_elemental',  'Illusion Chamber', 'Glowing elemental crystals illuminate the chamber.', 'https://the-demiurge.com/DemiDevUnit/images/rooms/roomtypeillusion.png', None, '2025-04-24 12:00:00')
+    (21, 'illusion_elemental',  'Illusion Chamber', 'Glowing elemental crystals illuminate the chamber.', 'https://the-demiurge.com/DemiDevUnit/images/rooms/roomtypeillusion.png', None, '2025-04-24 12:00:00'),
+    (22, 'illusion_empty', 'Illusion Chamber', 'The illusion fades, leaving the chamber eerily empty.', 'https://the-demiurge.com/DemiDevUnit/images/rooms/roomtypeillusion.png', None, '2025-04-24 12:00:00'),
 ]
 
 # --- items --------------------------------------------------------------------
@@ -488,6 +489,18 @@ TABLES = {
             image_url     VARCHAR(255),
             default_enemy_id INT,
             created_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    ''',
+    # ---------- crystal_templates ----------
+    'crystal_templates': '''
+        CREATE TABLE IF NOT EXISTS crystal_templates (
+            template_id INT AUTO_INCREMENT PRIMARY KEY,
+            element_id  INT NOT NULL,
+            name        VARCHAR(100) NOT NULL,
+            description TEXT,
+            image_url   VARCHAR(255),
+            created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (element_id) REFERENCES elements(element_id) ON DELETE CASCADE
         )
     ''',
     # ---------- npc_vendors ----------
@@ -877,6 +890,7 @@ TABLE_ORDER = [
     'players',
     'floors',
     'room_templates',
+    'crystal_templates',
     'npc_vendors',
     'items',
     'npc_vendor_items',
@@ -1039,6 +1053,13 @@ def insert_room_templates(cur):
         [row[1:] for row in MERGED_ROOM_TEMPLATES]
     )
     logger.info("Inserted room_templates.")
+
+def insert_crystal_templates(cur):
+    logger.info("Checking crystal_templates seed data…")
+    if not table_is_empty(cur, "crystal_templates"):
+        logger.info("crystal_templates already populated – skipping")
+    else:
+        logger.info("No default crystal template seed data.")
 
 def insert_npc_vendors(cur):
     logger.info("Checking npc_vendors seed data…")
@@ -1243,6 +1264,7 @@ def main() -> None:
                 insert_levels(cur)
                 insert_intro_steps(cur)
                 insert_room_templates(cur)
+                insert_crystal_templates(cur)
                 insert_npc_vendors(cur)
                 insert_items(cur)
                 insert_enemies_and_abilities(cur)

--- a/game/embed_manager.py
+++ b/game/embed_manager.py
@@ -631,27 +631,29 @@ class EmbedManager(commands.Cog):
         crystals: List[Dict[str, Any]],
         index: int = 0,
     ) -> None:
-        """Display the elemental crystals for the illusion challenge."""
-        lines = []
-        for i, c in enumerate(crystals):
-            icon = {
-                "Fire": "🔥",
-                "Ice": "❄️",
-                "Holy": "✨",
-                "Non-Elemental": "🌟",
-                "Air": "💨",
-            }.get(c.get("element_name"), "")
-            prefix = "➡️" if i == index else "▫️"
-            lines.append(f"{prefix} Crystal {i + 1}: {icon} {c.get('element_name')}")
-        desc = "Use elemental skills to shatter each crystal in order."
+        """Display the current crystal for the illusion challenge."""
+        if crystals:
+            if index >= len(crystals):
+                index = len(crystals) - 1
+            current = crystals[index]
+        else:
+            current = {}
+        desc = current.get("description", "A mysterious crystal shimmers here.")
         embed = discord.Embed(
-            title="🔮 Elemental Crystals",
+            title=f"🔮 Crystal {index + 1}/{len(crystals) if crystals else 1}",
             description=desc,
             color=discord.Color.purple(),
         )
-        if lines:
-            embed.add_field(name="Crystals", value="\n".join(lines), inline=False)
-        buttons = [("Skill", discord.ButtonStyle.primary, "combat_skill_menu", 0)]
+        if current.get("image_url"):
+            embed.set_image(url=f"{current['image_url']}?t={int(time.time())}")
+        buttons = [
+            ("Use",        discord.ButtonStyle.success,   "action_use",        0),
+            ("Skill",      discord.ButtonStyle.primary,   "combat_skill_menu", 0),
+            ("Character",  discord.ButtonStyle.danger,    "action_character", 0),
+            ("Look Around",discord.ButtonStyle.secondary, "action_look_around",0),
+            ("Menu",       discord.ButtonStyle.secondary, "action_menu",      0),
+            ("Leave Room", discord.ButtonStyle.secondary, "illusion_leave_room",0),
+        ]
         await self.send_or_update_embed(
             interaction,
             _ZWSP,

--- a/tests/test_crystal_templates.py
+++ b/tests/test_crystal_templates.py
@@ -1,0 +1,103 @@
+import types
+import sys
+import random
+import pytest
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub discord and mysql modules
+sys.modules.setdefault("mysql", types.ModuleType("mysql"))
+sys.modules.setdefault("mysql.connector", types.ModuleType("connector"))
+sys.modules.setdefault("aiomysql", types.ModuleType("aiomysql"))
+sys.modules["mysql"].connector = sys.modules["mysql.connector"]
+conn_mod = sys.modules["mysql.connector"]
+conn_mod.connection = types.SimpleNamespace(MySQLConnection=object)
+conn_mod.Error = Exception
+sys.modules.setdefault("discord", types.ModuleType("discord"))
+sys.modules.setdefault("discord.ext", types.ModuleType("ext"))
+ext_mod = sys.modules["discord.ext"]
+ext_mod.commands = types.ModuleType("commands")
+sys.modules["discord.ext.commands"] = ext_mod.commands
+ext_mod.commands.Cog = type("Cog", (), {"listener": staticmethod(lambda *a, **k: (lambda f: f))})
+ext_mod.commands.Bot = object
+ext_mod.commands.command = lambda *a, **k: (lambda f: f)
+ext_mod.commands.has_guild_permissions = lambda **k: (lambda f: f)
+ext_mod.commands.has_permissions = lambda **k: (lambda f: f)
+ext_mod.commands.Context = object
+
+discord = sys.modules["discord"]
+discord.InteractionType = types.SimpleNamespace(component=1)
+discord.ui = types.SimpleNamespace(View=object, Button=object)
+discord.ui.button = lambda *a, **k: (lambda f: f)
+discord.ButtonStyle = types.SimpleNamespace(primary=1, secondary=2, success=3, danger=4, blurple=5)
+discord.Color = types.SimpleNamespace(gold=lambda: None, blue=lambda: None, purple=lambda: None, green=lambda: None)
+discord.Interaction = type("Interaction", (), {})
+discord.Thread = type("Thread", (), {})
+discord.Member = type("Member", (), {})
+discord.Guild = type("Guild", (), {})
+discord.Message = type("Message", (), {})
+discord.TextChannel = type("TextChannel", (), {})
+discord.ChannelType = types.SimpleNamespace(private_thread=1)
+discord.Embed = type("Embed", (), {"__init__": lambda self, **k: None, "add_field": lambda *a, **k: None, "set_footer": lambda *a, **k: None, "set_image": lambda *a, **k: None})
+
+discord.Interaction = type("Interaction", (), {"channel": type("Ch", (), {"id": 1})(), "followup": type("F", (), {"send": lambda *a, **k: None})(), "response": type("R", (), {"is_done": lambda self: True})()})
+
+def test_tables_include_crystal_templates():
+    from database import database_setup as ds
+
+    assert 'crystal_templates' in ds.TABLES
+    idx = ds.TABLE_ORDER.index('room_templates')
+    assert ds.TABLE_ORDER[idx + 1] == 'crystal_templates'
+
+def test_start_illusion_challenge_fetches_crystals(monkeypatch):
+    ext_mod.commands.Cog = type("Cog", (), {"listener": staticmethod(lambda *a, **k: (lambda f: f))})
+    discord.Interaction = type("Interaction", (), {"channel": type("Ch", (), {"id": 1})(), "followup": type("F", (), {"send": lambda *a, **k: None})(), "response": type("R", (), {"is_done": lambda self: True})()})
+    from game import game_master
+    from core.game_session import GameSession
+
+    bot = types.SimpleNamespace(get_cog=lambda name: None)
+    gm = game_master.GameMaster(bot)
+    session = GameSession(1, 1, "t", 1)
+
+    sm = types.SimpleNamespace(get_session=lambda cid: session)
+    async def dummy(*a, **k):
+        return None
+    em = types.SimpleNamespace(send_illusion_crystal_embed=dummy,
+                               send_illusion_embed=dummy)
+
+    def fake_get_cog(name):
+        return {'SessionManager': sm, 'EmbedManager': em}.get(name)
+
+    bot.get_cog = fake_get_cog
+
+    class FakeCursor:
+        def execute(self, *a, **k):
+            pass
+        def fetchall(self):
+            return [
+                {"template_id":1,"element_id":1,"name":"Fire","description":"D","image_url":"U"},
+                {"template_id":2,"element_id":2,"name":"Ice","description":"D","image_url":"U"},
+            ]
+        def close(self):
+            pass
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+    class FakeConn:
+        def cursor(self, dictionary=True):
+            return FakeCursor()
+        def close(self):
+            pass
+    monkeypatch.setattr(gm, 'db_connect', lambda: FakeConn())
+    monkeypatch.setattr(random, 'choice', lambda seq: 'elemental_crystal')
+    interaction = discord.Interaction()
+    pytest.run_coroutine = lambda coro: coro
+    # call
+    import asyncio
+    loop = asyncio.new_event_loop()
+    loop.run_until_complete(gm.start_illusion_challenge(interaction, {}))
+    loop.close()
+    assert session.game_state.get('illusion_crystal_order')
+    assert session.game_state['illusion_challenge']['type'] == 'elemental_crystal'
+


### PR DESCRIPTION
## Summary
- create `crystal_templates` table and include in setup
- seed data updated for new empty illusion template
- select crystals from new table during elemental challenge
- show crystal image/info and add Leave Room button
- handle leaving or failing a crystal room
- unit tests for crystal templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851ef371a308328b738885d2b96ea01