### PR TITLE
Add empty illusion room and handle crystal failure

### DIFF
--- a/database/database_setup.py
+++ b/database/database_setup.py
@@ -180,6 +180,9 @@ MERGED_ROOM_TEMPLATES: List[Tuple] = [
         None, '2025-04-24 12:00:00'),
     (21, 'illusion',  'Illusion Chamber', 'Glowing elemental crystals illuminate the chamber.',
         'https://the-demiurge.com/DemiDevUnit/images/rooms/roomtypeillusion.png',
+        None, '2025-04-24 12:00:00'),
+    (22, 'illusion',  'Empty Illusion Chamber', 'The illusions fade away leaving only an empty space.',
+        'https://the-demiurge.com/DemiDevUnit/images/rooms/illusion_empty.png',
         None, '2025-04-24 12:00:00')
 ]
 

--- a/game/game_master.py
+++ b/game/game_master.py
@@ -2124,6 +2124,54 @@ class GameMaster(commands.Cog):
                 session.game_state.pop("illusion_crystal_index", None)
                 await self.handle_illusion_choice(interaction, challenge["answer"])
                 return
+        else:
+            # wrong element → illusions dissipate
+            session.game_state.pop("illusion_crystal_order", None)
+            session.game_state.pop("illusion_crystal_index", None)
+
+            conn = self.db_connect()
+            with conn.cursor(dictionary=True) as cur:
+                cur.execute(
+                    "SELECT coord_x, coord_y, current_floor_id FROM players WHERE player_id=%s AND session_id=%s",
+                    (interaction.user.id, session.session_id),
+                )
+                pos = cur.fetchone()
+            conn.close()
+            if pos:
+                x, y, floor = pos["coord_x"], pos["coord_y"], pos["current_floor_id"]
+
+                conn = self.db_connect()
+                with conn.cursor(dictionary=True) as cur:
+                    cur.execute(
+                        "SELECT description, image_url FROM room_templates WHERE template_id=%s",
+                        (22,),
+                    )
+                    tpl = cur.fetchone() or {}
+                    cur.execute(
+                        "UPDATE rooms SET description=%s, image_url=%s, default_enemy_id=NULL WHERE session_id=%s AND floor_id=%s AND coord_x=%s AND coord_y=%s",
+                        (
+                            tpl.get("description"),
+                            tpl.get("image_url"),
+                            session.session_id,
+                            floor,
+                            x,
+                            y,
+                        ),
+                    )
+                conn.commit(); conn.close()
+
+                conn = self.db_connect()
+                with conn.cursor(dictionary=True) as cur:
+                    cur.execute(
+                        "SELECT r.*, f.floor_number FROM rooms r JOIN floors f ON f.floor_id=r.floor_id WHERE r.session_id=%s AND r.floor_id=%s AND r.coord_x=%s AND r.coord_y=%s",
+                        (session.session_id, floor, x, y),
+                    )
+                    new_room = cur.fetchone()
+                conn.close()
+
+                await self.update_room_view(interaction, new_room, x, y)
+                await self.end_player_turn(interaction)
+                return
 
         em = self.bot.get_cog("EmbedManager")
         if em:


### PR DESCRIPTION
## Summary
- add Empty Illusion Chamber template
- dissipate crystals on wrong element and reveal the empty illusion room

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68520b7c30dc83288c1ff6cdc033f255