### PR TITLE
Add tests for database setup and GameMaster illusion challenge

### DIFF
--- a/tests/test_database_setup.py
+++ b/tests/test_database_setup.py
@@ -1,0 +1,104 @@
+import os
+import sys
+import types
+
+# Stub mysql and discord modules similar to existing tests
+sys.modules.setdefault("mysql", types.ModuleType("mysql"))
+sys.modules.setdefault("mysql.connector", types.ModuleType("connector"))
+sys.modules.setdefault("aiomysql", types.ModuleType("aiomysql"))
+sys.modules["mysql"].connector = sys.modules["mysql.connector"]
+sys.modules["mysql.connector"].connection = types.SimpleNamespace(MySQLConnection=object)
+sys.modules["mysql.connector"].Error = Exception
+
+sys.modules.setdefault("discord", types.ModuleType("discord"))
+sys.modules.setdefault("discord.ext", types.ModuleType("ext"))
+ext_mod = sys.modules["discord.ext"]
+ext_mod.commands = types.ModuleType("commands")
+sys.modules["discord.ext.commands"] = ext_mod.commands
+ext_mod.commands.Cog = type("Cog", (), {})
+ext_mod.commands.Bot = object
+ext_mod.commands.command = lambda *a, **k: (lambda f: f)
+ext_mod.commands.Cog.listener = lambda *a, **k: (lambda f: f)
+ext_mod.commands.has_guild_permissions = lambda **k: (lambda f: f)
+ext_mod.commands.has_permissions = lambda **k: (lambda f: f)
+ext_mod.commands.Context = object
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import importlib
+
+from database import database_setup
+
+class FakeCursor:
+    def __init__(self, log):
+        self.log = log
+        self.result = None
+    def execute(self, sql, params=None):
+        self.log.append(sql)
+        if sql.startswith("SELECT COUNT(*) FROM"):
+            self.result = (0,)
+        elif sql.startswith("SHOW COLUMNS"):
+            self.result = None
+        else:
+            self.result = None
+    def executemany(self, sql, params):
+        self.log.append(sql)
+    def fetchone(self):
+        return self.result
+    def fetchall(self):
+        return []
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+    def close(self):
+        pass
+
+class FakeConnection:
+    def __init__(self, log):
+        self.log = log
+    def cursor(self, dictionary=False):
+        return FakeCursor(self.log)
+    def commit(self):
+        pass
+    def close(self):
+        pass
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+def test_main_creates_crystal_templates(monkeypatch):
+    log = []
+    monkeypatch.setattr(
+        database_setup.mysql.connector,
+        "connect",
+        lambda **kw: FakeConnection(log),
+        raising=False,
+    )
+    # Skip column checks and seed inserts
+    monkeypatch.setattr(database_setup, "ensure_all_columns", lambda cur: None)
+    for fn in [
+        "insert_difficulties",
+        "insert_floor_room_rules",
+        "insert_elements",
+        "insert_abilities_and_classes",
+        "insert_levels",
+        "insert_intro_steps",
+        "insert_room_templates",
+        "insert_crystal_templates",
+        "insert_npc_vendors",
+        "insert_items",
+        "insert_enemies_and_abilities",
+        "insert_enemy_drops",
+        "insert_enemy_resistances",
+        "insert_npc_vendor_items",
+        "insert_new_relational_tables",
+        "insert_hub_embeds",
+    ]:
+        monkeypatch.setattr(database_setup, fn, lambda cur: None)
+
+    database_setup.main()
+
+    assert any("CREATE TABLE" in q and "crystal_templates" in q for q in log)

--- a/tests/test_start_illusion.py
+++ b/tests/test_start_illusion.py
@@ -1,0 +1,109 @@
+import sys
+import types
+import random
+import os
+import pytest
+
+# Stub mysql and discord modules like other tests
+sys.modules.setdefault("mysql", types.ModuleType("mysql"))
+sys.modules.setdefault("mysql.connector", types.ModuleType("connector"))
+sys.modules.setdefault("aiomysql", types.ModuleType("aiomysql"))
+sys.modules["mysql"].connector = sys.modules["mysql.connector"]
+sys.modules["mysql.connector"].connection = types.SimpleNamespace(MySQLConnection=object)
+sys.modules["mysql.connector"].Error = Exception
+
+sys.modules.setdefault("discord", types.ModuleType("discord"))
+sys.modules.setdefault("discord.ext", types.ModuleType("ext"))
+ext_mod = sys.modules["discord.ext"]
+ext_mod.commands = types.ModuleType("commands")
+sys.modules["discord.ext.commands"] = ext_mod.commands
+ext_mod.commands.Cog = type("Cog", (), {})
+ext_mod.commands.Bot = object
+ext_mod.commands.command = lambda *a, **k: (lambda f: f)
+ext_mod.commands.Cog.listener = lambda *a, **k: (lambda f: f)
+ext_mod.commands.has_guild_permissions = lambda **k: (lambda f: f)
+ext_mod.commands.has_permissions = lambda **k: (lambda f: f)
+ext_mod.commands.Context = object
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import types as typ
+
+from game.game_master import GameMaster
+from core.game_session import GameSession
+
+class FakeCursor:
+    def __init__(self, rows):
+        self.rows = rows
+    def execute(self, sql, params=None):
+        pass
+    def fetchall(self):
+        return self.rows
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+    def close(self):
+        pass
+
+class FakeConnection:
+    def __init__(self, rows):
+        self.rows = rows
+    def cursor(self, dictionary=False):
+        return FakeCursor(self.rows)
+    def close(self):
+        pass
+
+class FakeSessionManager:
+    def __init__(self, session):
+        self.session = session
+    def get_session(self, thread_id):
+        return self.session
+
+class FakeEmbedManager:
+    async def send_illusion_crystal_embed(self, *a, **k):
+        pass
+    async def send_illusion_embed(self, *a, **k):
+        pass
+
+class FakeBot:
+    def __init__(self, sm, em):
+        self.sm = sm
+        self.em = em
+    def get_cog(self, name):
+        return {"SessionManager": self.sm, "EmbedManager": self.em}.get(name)
+
+class FakeFollowup:
+    async def send(self, *a, **k):
+        pass
+
+class FakeInteraction:
+    def __init__(self):
+        self.channel = typ.SimpleNamespace(id=1)
+        self.followup = FakeFollowup()
+
+def test_start_illusion_challenge_order(monkeypatch):
+    session = GameSession(1, 1, "1", 1)
+    sm = FakeSessionManager(session)
+    em = FakeEmbedManager()
+    bot = FakeBot(sm, em)
+    gm = GameMaster(bot)
+
+    crystals = [
+        {"element_id": 1, "element_name": "Fire", "name": "F", "description": "", "image_url": ""},
+        {"element_id": 2, "element_name": "Ice", "name": "I", "description": "", "image_url": ""},
+        {"element_id": 3, "element_name": "Holy", "name": "H", "description": "", "image_url": ""},
+    ]
+
+    monkeypatch.setattr(gm, "db_connect", lambda: FakeConnection(crystals))
+    monkeypatch.setattr(random, "choice", lambda seq: "elemental_crystal")
+    def fake_randint(a, b):
+        return 4 if (a, b) == (2, 6) else 0
+
+    monkeypatch.setattr(random, "randint", fake_randint)
+
+    interaction = FakeInteraction()
+    import asyncio
+    asyncio.run(gm.start_illusion_challenge(interaction, {"description": ""}))
+    order = session.game_state.get("illusion_crystal_order", [])
+    assert 2 <= len(order) <= 6


### PR DESCRIPTION
## Summary
- ensure `database_setup.main()` creates `crystal_templates` table
- test `GameMaster.start_illusion_challenge` crystal order logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68520cb4bcac8328bca953ecdf8f56c3