### PR TITLE
Update illusion crystal info display

### DIFF
--- a/game/embed_manager.py
+++ b/game/embed_manager.py
@@ -643,12 +643,14 @@ class EmbedManager(commands.Cog):
             }.get(c.get("element_name"), "")
             prefix = "➡️" if i == index else "▫️"
             lines.append(f"{prefix} Crystal {i + 1}: {icon} {c.get('element_name')}")
-        desc = "Use elemental skills to shatter each crystal in order."
+        current = crystals[index] if 0 <= index < len(crystals) else {}
         embed = discord.Embed(
-            title="🔮 Elemental Crystals",
-            description=desc,
+            title=f"🔮 {current.get('name', 'Elemental Crystals')}",
+            description=current.get("description", "Use elemental skills to shatter each crystal in order."),
             color=discord.Color.purple(),
         )
+        if img := current.get("image_url"):
+            embed.set_image(url=f"{img}?t={int(time.time())}")
         if lines:
             embed.add_field(name="Crystals", value="\n".join(lines), inline=False)
         # Build two rows of actions. Row 0 mirrors the standard in-room actions

--- a/game/game_master.py
+++ b/game/game_master.py
@@ -2112,6 +2112,9 @@ class GameMaster(commands.Cog):
             idx = len(crystals) - 1
 
         current = crystals[idx]
+        if ability.get("element_id") is None:
+            await interaction.followup.send("The crystal has no reaction.", ephemeral=True)
+            return
         if ability.get("element_id") == current.get("element_id"):
             self.append_game_log(session.session_id, f"{interaction.user.display_name} shatters the {current['element_name']} crystal!")
             idx += 1


### PR DESCRIPTION
## Summary
- show current crystal details and image in illusion challenge
- add no-element handling when casting skills on crystals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68520e737ca883289377c92cf315b4e0