### PR TITLE
Fix parse_columns to ignore REFERENCES lines

### DIFF
--- a/database/database_setup.py
+++ b/database/database_setup.py
@@ -1230,7 +1230,7 @@ def _parse_columns(create_sql: str) -> list[tuple[str, str]]:
     columns = []
     for line in inside.splitlines():
         line = line.strip().rstrip(",")
-        if not line or line.upper().startswith(("PRIMARY KEY", "FOREIGN KEY")):
+        if not line or line.upper().startswith(("PRIMARY KEY", "FOREIGN KEY", "REFERENCES")):
             continue
         m = re.match(r"`?([A-Za-z_][A-Za-z0-9_]*)`?\s+(.*)", line)
         if m:

--- a/tests/test_database_setup.py
+++ b/tests/test_database_setup.py
@@ -102,3 +102,19 @@ def test_main_creates_crystal_templates(monkeypatch):
     database_setup.main()
 
     assert any("CREATE TABLE" in q and "crystal_templates" in q for q in log)
+
+
+def test_parse_columns_skips_fk_reference_lines():
+    sql = """
+    CREATE TABLE test (
+        id INT,
+        item_id INT,
+        FOREIGN KEY (item_id)
+            REFERENCES items(item_id)
+    );
+    """
+    cols = database_setup._parse_columns(sql)
+    assert cols == [
+        ("id", "INT"),
+        ("item_id", "INT"),
+    ]


### PR DESCRIPTION
## Summary
- tweak `_parse_columns` to skip REFERENCES lines as well
- test parsing of FK/REFERENCES blocks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685213a5571083289ddf5476d780de01