### PR TITLE
Fix absorb logic to heal enemies

### DIFF
--- a/tests/test_ability_engine.py
+++ b/tests/test_ability_engine.py
@@ -22,7 +22,10 @@ class FakeCursor:
     def execute(self, sql, params=None):
         for r in self.rows:
             if r["enemy_id"] == params[0] and r["element_id"] == params[1]:
-                self.result = {"multiplier": r["multiplier"]}
+                self.result = {
+                    "multiplier": r["multiplier"],
+                    "relation": r.get("relation", "normal"),
+                }
                 break
         else:
             self.result = None
@@ -69,10 +72,13 @@ def test_weakness_multiplier(monkeypatch):
 
 
 def test_absorb_multiplier(monkeypatch):
-    engine = make_engine([{"enemy_id": 1, "element_id": 1, "multiplier": -1}], monkeypatch)
+    engine = make_engine([
+        {"enemy_id": 1, "element_id": 1, "multiplier": -1, "relation": "absorb"}
+    ], monkeypatch)
     user, enemy, ability = base_entities()
     result = engine.resolve(user, enemy, ability)
-    assert result.amount == -10
+    assert result.type == "heal"
+    assert result.amount == 10
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- handle elemental absorption by converting damage into healing in `AbilityEngine`
- return elemental relation from `fetch_enemy_resistance`
- adjust `AbilityEngine` elemental multiplier helper and call sites
- update tests for absorption logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852297d4ea0832890ecb8e130ce383b