### PR TITLE
Fix deferred response for Use button

### DIFF
--- a/game/battle_system.py
+++ b/game/battle_system.py
@@ -1346,6 +1346,12 @@ class BattleSystem(commands.Cog):
     #                          Inventory / flee                             #
     # --------------------------------------------------------------------- #
     async def handle_item_menu(self, interaction: discord.Interaction) -> None:
+        if not interaction.response.is_done():
+            try:
+                await interaction.response.defer()
+            except discord.errors.HTTPException as e:
+                logger.debug("Deferred interaction failed: %s", e)
+
         inv = self.bot.get_cog("InventoryShop")
         if inv:
             return await inv.display_use_item_menu(interaction)

--- a/game/game_master.py
+++ b/game/game_master.py
@@ -2724,6 +2724,12 @@ class GameMaster(commands.Cog):
         if cid == "action_use":
             inv = self.bot.get_cog("InventoryShop")
             if inv:
+                if not interaction.response.is_done():
+                    defer_fn = getattr(interaction.response, "defer_update", None)
+                    if callable(defer_fn):
+                        await defer_fn()
+                    else:
+                        await interaction.response.defer()
                 return await inv.display_use_item_menu(interaction)
         # Use-stairs
         if cid == "action_use_stairs":


### PR DESCRIPTION
## Summary
- prevent interaction failure by deferring when clicking **Use**
- ensure battle item menu also defers before processing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a3deb74c8328bfde7ad671f95125