### PR TITLE
Implement deterministic illusion challenges

### DIFF
--- a/game/dungeon_generator.py
+++ b/game/dungeon_generator.py
@@ -793,6 +793,8 @@ class DungeonGenerator(commands.Cog):
                 tmpl = self.fetch_random_template(rtype) or {}
                 desc = tmpl.get("description", "A mysterious room…")
                 img = tmpl.get("image_url")
+                if rtype == "illusion" and inner_id is None:
+                    inner_id = tmpl.get("template_id")
                 if def_en is None:
                     def_en = tmpl.get("default_enemy_id")
 
@@ -943,6 +945,8 @@ class DungeonGenerator(commands.Cog):
             tmpl = self.fetch_random_template(rtype) or {}
             desc = tmpl.get("description", "A mysterious room…")
             img = tmpl.get("image_url")
+            if rtype == "illusion" and inner_id is None:
+                inner_id = tmpl.get("template_id")
 
             if rtype == "boss":
                 role = "boss"
@@ -1246,6 +1250,8 @@ class DungeonGenerator(commands.Cog):
                     tmpl = self.fetch_random_template(rtype) or {}
                     desc = tmpl.get("description") or "A mysterious room..."
                     img = tmpl.get("image_url")
+                    if rtype == "illusion" and inner_id is None:
+                        inner_id = tmpl.get("template_id")
 
                     if rtype in ("miniboss", "boss", "monster"):
                         role = (

--- a/game/embed_manager.py
+++ b/game/embed_manager.py
@@ -628,28 +628,18 @@ class EmbedManager(commands.Cog):
         crystals: List[Dict[str, Any]],
         index: int = 0,
     ) -> None:
-        """Display the elemental crystals for the illusion challenge."""
-        lines = []
-        for i, c in enumerate(crystals):
-            icon = {
-                "Fire": "🔥",
-                "Ice": "❄️",
-                "Holy": "✨",
-                "Non-Elemental": "🌟",
-                "Air": "💨",
-            }.get(c.get("element_name"), "")
-            prefix = "➡️" if i == index else "▫️"
-            lines.append(f"{prefix} Crystal {i + 1}: {icon} {c.get('element_name')}")
+        """Display a single elemental crystal for the illusion challenge."""
         current = crystals[index] if 0 <= index < len(crystals) else {}
         embed = discord.Embed(
-            title=f"🔮 {current.get('name', 'Elemental Crystals')}",
-            description=current.get("description", "Use elemental skills to shatter each crystal in order."),
+            title=f"🔮 {current.get('name', 'Elemental Crystal')}",
+            description=current.get(
+                "description", "Use an elemental skill to attune the crystal."
+            ),
             color=discord.Color.purple(),
         )
         if img := current.get("image_url"):
             embed.set_image(url=f"{img}?t={int(time.time())}")
-        if lines:
-            embed.add_field(name="Crystals", value="\n".join(lines), inline=False)
+        embed.set_footer(text=f"Crystal {index + 1} of {len(crystals)}")
         # Build two rows of actions. Row 0 mirrors the standard in-room actions
         # (Look Around, Skill, Use, Character, Menu) with an additional option
         # to abandon the illusion room.

--- a/game/game_master.py
+++ b/game/game_master.py
@@ -343,11 +343,19 @@ class GameMaster(commands.Cog):
         if not session:
             return await interaction.followup.send("❌ No session.", ephemeral=True)
 
-        challenge_type = random.choice([
-            "guess_room",
-            "elemental_crystal",
-            "enemy_count",
-        ])
+        tpl_id = room_info.get("inner_template_id")
+        mapping = {
+            19: "enemy_count",
+            20: "guess_room",
+            21: "elemental_crystal",
+        }
+        challenge_type = mapping.get(tpl_id)
+        if not challenge_type:
+            challenge_type = random.choice([
+                "guess_room",
+                "elemental_crystal",
+                "enemy_count",
+            ])
 
         if challenge_type == "guess_room":
             if not room_info.get("image_url"):
@@ -418,14 +426,7 @@ class GameMaster(commands.Cog):
             await em.send_illusion_count_embed(interaction, room_info, options)
             return
         else:  # elemental_crystal
-            mapping = [
-                "illusion_enemy",
-                "illusion_treasure",
-                "illusion_vendor",
-                "illusion_empty",
-            ]
-            idx = random.randint(0, 3)
-            answer = mapping[idx]
+            answer = "illusion_treasure"
 
             conn = self.db_connect()
             with conn.cursor(dictionary=True) as cur:
@@ -450,8 +451,7 @@ class GameMaster(commands.Cog):
 
             desc = (
                 f"{room_info.get('description', 'The room shimmers mysteriously.')}\n\n"
-                f"{len(crystals)} elemental crystals glow faintly. "
-                "Only one dispels the mirage."
+                f"Attune {len(crystals)} elemental crystals in sequence."
             )
 
             session.game_state['illusion_crystal_order'] = crystals

--- a/tests/test_start_illusion.py
+++ b/tests/test_start_illusion.py
@@ -129,7 +129,8 @@ def test_start_illusion_challenge_order(monkeypatch):
 
     interaction = FakeInteraction()
     import asyncio
-    asyncio.run(gm.start_illusion_challenge(interaction, {"description": ""}))
+    room = {"description": "", "inner_template_id": 21}
+    asyncio.run(gm.start_illusion_challenge(interaction, room))
     order = session.game_state.get("illusion_crystal_order", [])
     assert 2 <= len(order) <= 6
 
@@ -141,17 +142,16 @@ def test_start_illusion_guess_room(monkeypatch):
     bot = FakeBot(sm, em)
     gm = GameMaster(bot)
 
-    choices = ["guess_room", "illusion_enemy"]
-
     def fake_choice(seq):
-        return choices.pop(0)
+        return "illusion_enemy"
 
     monkeypatch.setattr(random, "choice", fake_choice)
     monkeypatch.setattr(gm, "db_connect", lambda: FakeConnection([{"image_url": "dark.png"}]))
 
     interaction = FakeInteraction()
     import asyncio
-    asyncio.run(gm.start_illusion_challenge(interaction, {"description": ""}))
+    room = {"description": "", "inner_template_id": 20}
+    asyncio.run(gm.start_illusion_challenge(interaction, room))
 
     challenge = session.game_state.get("illusion_challenge")
     assert challenge["type"] == "guess_room"
@@ -183,7 +183,8 @@ def test_start_illusion_enemy_count(monkeypatch):
 
     interaction = FakeInteraction()
     import asyncio
-    asyncio.run(gm.start_illusion_challenge(interaction, {"description": ""}))
+    room = {"description": "", "inner_template_id": 19}
+    asyncio.run(gm.start_illusion_challenge(interaction, room))
 
     challenge = session.game_state.get("illusion_challenge")
     assert challenge["type"] == "enemy_count"


### PR DESCRIPTION
## Summary
- ensure illusion crystal embed shows one crystal at a time
- map illusion template IDs to challenge types
- always reward chest after completing crystal sequence
- store illusion template IDs in dungeon generator
- update tests for deterministic challenges

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a58ca6a08328a9c4526c42976af7