### PR TITLE
Add speed modifiers and update ability seeds

### DIFF
--- a/database/database_setup.py
+++ b/database/database_setup.py
@@ -51,7 +51,8 @@ def table_is_empty(cur, table_name: str) -> bool:
 # ═══════════════════════════════════════════════════════════════════════════
 
 # --- abilities ----------------------------------------------------------------
-[    (1, 'Cure', 'Heals a small amount of HP.', '{"heal": 50}', 1, '❤️', 'self', None, None, None, None, '2025-03-31 07:40:47', 'magic_power'),
+MERGED_ABILITIES: List[Tuple] = [
+    (1, 'Cure', 'Heals a small amount of HP.', '{"heal": 50}', 1, '❤️', 'self', None, None, None, None, '2025-03-31 07:40:47', 'magic_power'),
     (2, 'Fire', 'Deals fire damage to an enemy.', '{"base_damage": 50}', 1, '🔥', 'enemy', None, 1, None, None, '2025-03-31 07:40:47', 'magic_power'),
     (3, 'Blizzard', 'Deals ice damage to an enemy.', '{"base_damage": 50}', 1, '❄️', 'enemy', None, 2, None, None, '2025-03-31 07:40:47', 'magic_power'),
     (4, 'Holy', 'Deals holy damage to one enemy.', '{"base_damage": 100}', 1, '✨', 'enemy', None, 3, None, None, '2025-03-31 07:40:47', 'magic_power'),
@@ -83,8 +84,8 @@ def table_is_empty(cur, table_name: str) -> bool:
     (30, 'Blink', 'Raises your evasion.', '{"evasion_up": 30}', 2, '🎯🔼', 'self', None, None, 10, 5, '2025-04-03 12:43:43', 'magic_power'),
     (31, 'Demi', 'Deals damaged based on enemy health.', '{"percent_damage": 0.25}', 1, '🌀', 'enemy', None, 4, None, None, '2025-04-03 12:43:43', 'attack_power'),
     (32, 'Gravity', 'Deals Air based damage while grounding flying enemies.', '{"base_damage": 80}', 1, '🪐', 'enemy', None, None, None, None, '2025-04-03 12:43:43', 'magic_power'),
-    (33, 'Haste', 'Grants higher speed with chance of increasing turns.', None, 3, '⏱️🔼', 'self', None, None, None, None, '2025-04-03 12:43:43', 'magic_power'),
-    (34, 'Slow', 'Lowers enemy speed with chance of reducing turns.', None, 2, '⏳🔽', 'enemy', None, None, None, None, '2025-04-03 12:43:43', 'magic_power'),
+    (33, 'Haste', 'Grants higher speed with chance of increasing turns.', '{"speed_up": 30, "duration": 3}', 3, '⏱️🔼', 'self', None, None, None, None, '2025-04-03 12:43:43', 'magic_power'),
+    (34, 'Slow', 'Lowers enemy speed with chance of reducing turns.', '{"speed_down": 30, "duration": 2}', 2, '⏳🔽', 'enemy', None, None, None, None, '2025-04-03 12:43:43', 'magic_power'),
     (35, 'Poison', 'Deals a small amount of damage over time.', '{"damage_over_time": {"duration": 3, "damage_per_turn": 10}}', 3, '☠️', 'enemy', None, None, 3, 5, '2025-04-03 12:43:43', 'attack_power'),
     (36, 'Bio', 'Deals a greater amount of damage over time.', '{"damage_over_time": {"duration": 5, "damage_per_turn": 12}}', 5, '☣️', 'enemy', None, None, 8, 5, '2025-04-03 12:43:43', 'attack_power'),
     (37, 'Focus', 'Raises your magic power.', '{"magic_power_up": 30}', 1, '🔮🔼', 'self', None, None, 16, 5, '2025-04-03 12:43:43', 'attack_power'),

--- a/tests/test_ability_engine.py
+++ b/tests/test_ability_engine.py
@@ -129,3 +129,41 @@ def test_scan(monkeypatch):
     result = engine.resolve(user, enemy, ability)
     assert any("30/40" in line for line in result.logs)
     assert any("Fire" in line for line in result.logs)
+
+
+def test_healing_over_time(monkeypatch):
+    engine = make_engine([], monkeypatch)
+    user, enemy, ability = base_entities()
+    ability["ability_name"] = "Regen"
+    ability["effect"] = json.dumps({"healing_over_time": {"percent": 0.2, "duration": 2}})
+    result = engine.resolve(user, user, ability)
+    assert result.type == "hot"
+    assert result.dot["heal_per_turn"] == 10
+    assert result.dot["remaining"] == 2
+    assert result.status_effects[0]["effect_name"] == "Regen"
+
+
+def test_speed_up(monkeypatch):
+    engine = make_engine([], monkeypatch)
+    user, enemy, ability = base_entities()
+    ability["ability_name"] = "Haste"
+    ability["effect"] = json.dumps({"speed_up": 30, "duration": 3})
+    result = engine.resolve(user, user, ability)
+    assert result.type == "status"
+    se = result.status_effects[0]
+    assert se["effect_name"] == "Haste"
+    assert se["speed_up"] == 30
+    assert se["remaining"] == 3
+
+
+def test_speed_down(monkeypatch):
+    engine = make_engine([], monkeypatch)
+    user, enemy, ability = base_entities()
+    ability["ability_name"] = "Slow"
+    ability["effect"] = json.dumps({"speed_down": 20, "duration": 1})
+    result = engine.resolve(user, enemy, ability)
+    assert result.type == "status"
+    se = result.status_effects[0]
+    assert se["effect_name"] == "Slow"
+    assert se["speed_down"] == 20
+    assert se["remaining"] == 1

--- a/utils/ability_engine.py
+++ b/utils/ability_engine.py
@@ -397,6 +397,44 @@ class AbilityEngine:
                     }]
                 )
 
+            # speed_up (Haste)
+            elif result is None and "speed_up" in effect_data:
+                amount = effect_data["speed_up"]
+                duration = effect_data.get("duration", 1)
+                se_name = effect_data.get("status_name", name)
+                logs.append(
+                    f"{name} increases speed by {amount} for {duration} turn(s)."
+                )
+                result = AbilityResult(
+                    type="status",
+                    logs=logs,
+                    status_effects=[{
+                        "effect_name": se_name,
+                        "remaining": duration,
+                        "speed_up": amount,
+                        "target": ability.get("target_type", "self"),
+                    }]
+                )
+
+            # speed_down (Slow)
+            elif result is None and "speed_down" in effect_data:
+                amount = effect_data["speed_down"]
+                duration = effect_data.get("duration", 1)
+                se_name = effect_data.get("status_name", name)
+                logs.append(
+                    f"{name} decreases speed by {amount} for {duration} turn(s)."
+                )
+                result = AbilityResult(
+                    type="status",
+                    logs=logs,
+                    status_effects=[{
+                        "effect_name": se_name,
+                        "remaining": duration,
+                        "speed_down": amount,
+                        "target": ability.get("target_type", "enemy"),
+                    }]
+                )
+
             # scan
             elif result is None and effect_data.get("scan"):
                 ename = target.get("enemy_name", "Enemy")


### PR DESCRIPTION
## Summary
- define `MERGED_ABILITIES` seed list and populate Haste/Slow effects
- support `speed_up`/`speed_down` in `AbilityEngine`
- test new HoT and speed modifier handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68534514dd608328a257c1491aa32ea5