### PR TITLE
Fix world tick in GameMaster

### DIFF
--- a/game/game_master.py
+++ b/game/game_master.py
@@ -2356,8 +2356,10 @@ class GameMaster(commands.Cog):
         await self.advance_turn(interaction, interaction.channel.id)
 
         # 3️⃣ Tick world HoT/DoT on the player whose turn it now is
+        #     (only when not in combat)
         new_pid = session.current_turn
-        await engine.tick_world(new_pid)
+        if not session.battle_state:
+            await engine.tick_world(new_pid)
 
         # 4️⃣ Finally redraw that player’s view
         await sm.refresh_current_state(interaction)


### PR DESCRIPTION
## Summary
- tick world effects only when not in battle
- update comment accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853f7da390883289b6d504f4ae23b91