### PR TITLE
Fix speed advantage loop

### DIFF
--- a/game/battle_system.py
+++ b/game/battle_system.py
@@ -98,14 +98,17 @@ class BattleSystem(commands.Cog):
     def _check_speed_advantage(self, session: Any,
                                player: Dict[str, Any],
                                enemy: Dict[str, Any]) -> Optional[str]:
-        """Return 'player' or 'enemy' if either side beats the other's speed by ≥10."""
+        """Return ``"player"`` or ``"enemy"`` if either side beats the other's
+        speed by ≥10 and has not already gained an extra turn this round."""
         p_mod = self._apply_stat_modifiers(player, session.battle_state.get("player_effects", []))
         e_mod = self._apply_stat_modifiers(enemy,  session.battle_state.get("enemy_effects", []))
         ps = p_mod.get("speed", 0)
         es = e_mod.get("speed", 0)
-        if ps >= es + 10:
+        if ps >= es + 10 and session.battle_state.get("speed_advantage_used") != "player":
+            session.battle_state["speed_advantage_used"] = "player"
             return "player"
-        if es >= ps + 10:
+        if es >= ps + 10 and session.battle_state.get("speed_advantage_used") != "enemy":
+            session.battle_state["speed_advantage_used"] = "enemy"
             return "enemy"
         return None
 

--- a/game/game_master.py
+++ b/game/game_master.py
@@ -582,7 +582,6 @@ class GameMaster(commands.Cog):
             return await interaction.followup.send(
                 "❌ No session.", ephemeral=True
             )
-
         conn = self.db_connect()
         with conn.cursor() as cur:
             cur.execute(
@@ -2328,6 +2327,10 @@ class GameMaster(commands.Cog):
             return await interaction.followup.send(
                 "❌ No session.", ephemeral=True
             )
+
+        # reset any temporary speed advantage so it can trigger again next round
+        if session.battle_state:
+            session.battle_state.pop("speed_advantage_used", None)
 
         # 1️⃣ Identify outgoing player and prep the engine.  We no longer
         # tick effects here so they only trigger once when a player's new

--- a/tests/test_speed_advantage.py
+++ b/tests/test_speed_advantage.py
@@ -1,0 +1,69 @@
+import types
+import os
+import sys
+
+# Stub mysql and discord modules like other tests
+sys.modules.setdefault("mysql", types.ModuleType("mysql"))
+sys.modules.setdefault("mysql.connector", types.ModuleType("connector"))
+sys.modules.setdefault("aiomysql", types.ModuleType("aiomysql"))
+sys.modules["mysql"].connector = sys.modules["mysql.connector"]
+sys.modules["mysql.connector"].connection = types.SimpleNamespace(MySQLConnection=object)
+
+sys.modules.setdefault("discord", types.ModuleType("discord"))
+sys.modules.setdefault("discord.ext", types.ModuleType("ext"))
+ext_mod = sys.modules["discord.ext"]
+ext_mod.commands = types.ModuleType("commands")
+sys.modules["discord.ext.commands"] = ext_mod.commands
+ext_mod.commands.Cog = type("Cog", (), {})
+ext_mod.commands.Bot = object
+ext_mod.commands.command = lambda *a, **k: (lambda f: f)
+ext_mod.commands.Cog.listener = lambda *a, **k: (lambda f: f)
+ext_mod.commands.has_guild_permissions = lambda **k: (lambda f: f)
+ext_mod.commands.has_permissions = lambda **k: (lambda f: f)
+ext_mod.commands.Context = object
+
+discord = sys.modules["discord"]
+discord.InteractionType = types.SimpleNamespace(component=1)
+discord.ui = types.SimpleNamespace(View=object, Button=object)
+discord.ui.button = lambda *a, **k: (lambda f: f)
+discord.ButtonStyle = types.SimpleNamespace(primary=1, secondary=2, success=3, danger=4, blurple=5)
+discord.Color = types.SimpleNamespace(gold=lambda: None, blue=lambda: None, purple=lambda: None, green=lambda: None)
+discord.Interaction = type("Interaction", (), {})
+discord.Embed = type("Embed", (), {"__init__": lambda self, **k: None, "add_field": lambda *a, **k: None, "set_image": lambda *a, **k: None})
+discord.abc = types.SimpleNamespace(Messageable=object)
+discord.Message = type("Message", (), {})
+discord.Thread = type("Thread", (), {})
+discord.Member = type("Member", (), {})
+discord.Guild = type("Guild", (), {})
+discord.TextChannel = type("TextChannel", (), {})
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from game.battle_system import BattleSystem
+
+
+def test_speed_advantage_only_once():
+    bot = types.SimpleNamespace(get_cog=lambda name: None)
+    bs = BattleSystem(bot)
+
+    session = types.SimpleNamespace(
+        session_id=1,
+        current_turn=1,
+        battle_state={"player_effects": [], "enemy_effects": [], "enemy": {}},
+        game_log=[],
+    )
+
+    player = {"speed": 20}
+    enemy = {"speed": 0}
+
+    adv1 = bs._check_speed_advantage(session, player, enemy)
+    assert adv1 == "player"
+
+    adv2 = bs._check_speed_advantage(session, player, enemy)
+    assert adv2 is None
+
+    # simulate end of turn reset
+    session.battle_state.pop("speed_advantage_used", None)
+
+    adv3 = bs._check_speed_advantage(session, player, enemy)
+    assert adv3 == "player"


### PR DESCRIPTION
## Summary
- prevent repeated extra turns from speed advantage
- reset speed bonus flag each round
- test single extra turn handling

## Testing
- `pytest tests/test_speed_advantage.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68540555688883289471e4f0f5510113