### PR TITLE
Add ATB gauge display and readiness handling

### DIFF
--- a/game/battle_system.py
+++ b/game/battle_system.py
@@ -6,13 +6,18 @@ import time
 import logging
 import asyncio
 import random
-from utils.status_engine   import StatusEffectEngine
+from utils.status_engine import StatusEffectEngine
 from utils.ability_engine import AbilityEngine
 from game.atb_manager import ATBManager
 from utils.helpers import load_config
 from models.database import Database
 from typing import Any, Dict, List, Optional, Set, Tuple
-from utils.ui_helpers import create_progress_bar, create_cooldown_bar, format_status_effects, get_emoji_for_room_type
+from utils.ui_helpers import (
+    create_progress_bar,
+    create_cooldown_bar,
+    format_status_effects,
+    get_emoji_for_room_type,
+)
 from models.session_models import SessionPlayerModel
 
 logger = logging.getLogger("BattleSystem")
@@ -47,6 +52,7 @@ class BattleSystem(commands.Cog):
 
     async def adb_connect(self):
         from models.database import AsyncDatabase
+
         return await AsyncDatabase().get_connection()
 
     def create_bar(self, current: int, maximum: int, length: int = 10) -> str:
@@ -56,8 +62,8 @@ class BattleSystem(commands.Cog):
         filled = int(round(length * current / float(maximum)))
         bar = "█" * filled + "░" * (length - filled)
         return f"[{bar}] {current}/{maximum}"
-    
-    def _normalize_se(self, raw: Dict[str,Any]) -> Dict[str,Any]:
+
+    def _normalize_se(self, raw: Dict[str, Any]) -> Dict[str, Any]:
         """
         Turn raw engine output into exactly the 3 keys our UI helper wants:
           - icon (str)
@@ -66,17 +72,23 @@ class BattleSystem(commands.Cog):
         plus anything else your engine attaches (damage_per_turn, etc.)
         """
         out = {
-            "effect_id":   raw.get("effect_id"),
+            "effect_id": raw.get("effect_id"),
             "effect_name": raw.get("effect_name"),
-            "remaining":   raw.get("remaining", raw.get("remaining_turns", 0)),
-            "icon":        raw.get("icon") or raw.get("icon_url",""),
+            "remaining": raw.get("remaining", raw.get("remaining_turns", 0)),
+            "icon": raw.get("icon") or raw.get("icon_url", ""),
             # preserve any extra tick fields
-            **{k: v for k,v in raw.items() if k in ("damage_per_turn","heal_per_turn")}
+            **{
+                k: v
+                for k, v in raw.items()
+                if k in ("damage_per_turn", "heal_per_turn")
+            },
         }
         out["target"] = raw.get("target", "self")
         return out
 
-    def _apply_stat_modifiers(self, stats: Dict[str, Any], effects: List[Dict[str, Any]]) -> Dict[str, Any]:
+    def _apply_stat_modifiers(
+        self, stats: Dict[str, Any], effects: List[Dict[str, Any]]
+    ) -> Dict[str, Any]:
         """Return a copy of ``stats`` with attack/magic/defense buffs applied."""
         out = stats.copy()
         for se in effects or []:
@@ -98,12 +110,16 @@ class BattleSystem(commands.Cog):
 
         return out
 
-    def _check_speed_advantage(self, session: Any,
-                               player: Dict[str, Any],
-                               enemy: Dict[str, Any]) -> Optional[str]:
+    def _check_speed_advantage(
+        self, session: Any, player: Dict[str, Any], enemy: Dict[str, Any]
+    ) -> Optional[str]:
         """Return 'player' or 'enemy' if either side beats the other's speed by ≥10."""
-        p_mod = self._apply_stat_modifiers(player, session.battle_state.get("player_effects", []))
-        e_mod = self._apply_stat_modifiers(enemy,  session.battle_state.get("enemy_effects", []))
+        p_mod = self._apply_stat_modifiers(
+            player, session.battle_state.get("player_effects", [])
+        )
+        e_mod = self._apply_stat_modifiers(
+            enemy, session.battle_state.get("enemy_effects", [])
+        )
         ps = p_mod.get("speed", 0)
         es = e_mod.get("speed", 0)
         if ps >= es + 10:
@@ -116,6 +132,7 @@ class BattleSystem(commands.Cog):
         """Return ``True`` if an elemental crystal challenge is active."""
         ch = session.game_state.get("illusion_challenge") if session else None
         return isinstance(ch, dict) and ch.get("type") == "elemental_crystal"
+
     # --------------------------------------------------------------------- #
     #                     Room / Template utilities                         #
     # --------------------------------------------------------------------- #
@@ -141,7 +158,9 @@ class BattleSystem(commands.Cog):
             logger.error("Error fetching random safe template: %s", e)
             return None
 
-    async def _replace_monster_room_with_safe(self, session: Any, floor_id: int, x: int, y: int) -> int:
+    async def _replace_monster_room_with_safe(
+        self, session: Any, floor_id: int, x: int, y: int
+    ) -> int:
         try:
             conn = self.db_connect()
             cursor = conn.cursor(dictionary=True, buffered=True)
@@ -159,9 +178,12 @@ class BattleSystem(commands.Cog):
             )
             old_room = cursor.fetchone()
             if not old_room:
-                cursor.close(); conn.close(); return 0
+                cursor.close()
+                conn.close()
+                return 0
             old_exits, old_room_id = old_room["exits"], old_room["room_id"]
-            cursor.close(); conn.close()
+            cursor.close()
+            conn.close()
         except Exception as e:
             logger.error("Error fetching old room: %s", e)
             return 0
@@ -204,7 +226,9 @@ class BattleSystem(commands.Cog):
             logger.error("Error replacing monster room with safe room: %s", e)
             return 0
 
-    async def get_enemy_for_room(self, session: Any, floor_id: int, x: int, y: int) -> Optional[dict]:
+    async def get_enemy_for_room(
+        self, session: Any, floor_id: int, x: int, y: int
+    ) -> Optional[dict]:
         try:
             conn = self.db_connect()
             cursor = conn.cursor(dictionary=True)
@@ -213,7 +237,10 @@ class BattleSystem(commands.Cog):
                 (session.session_id,),
             )
             row = cursor.fetchone()
-            if not row: cursor.close(); conn.close(); return None
+            if not row:
+                cursor.close()
+                conn.close()
+                return None
             difficulty = (row["difficulty"] or "").capitalize()
 
             cursor.execute(
@@ -228,7 +255,10 @@ class BattleSystem(commands.Cog):
                 (session.session_id, floor_id, x, y),
             )
             room = cursor.fetchone()
-            if not room: cursor.close(); conn.close(); return None
+            if not room:
+                cursor.close()
+                conn.close()
+                return None
 
             expected_role = "miniboss" if room["room_type"] == "miniboss" else "normal"
 
@@ -248,8 +278,14 @@ class BattleSystem(commands.Cog):
                 (difficulty, expected_role),
             )
             enemy = cursor.fetchone()
-            cursor.close(); conn.close()
-            logger.debug("Selected enemy for %s (%s): %s", room["room_type"], expected_role, enemy)
+            cursor.close()
+            conn.close()
+            logger.debug(
+                "Selected enemy for %s (%s): %s",
+                room["room_type"],
+                expected_role,
+                enemy,
+            )
             return enemy
         except Exception as e:
             logger.error("Error in get_enemy_for_room: %s", e)
@@ -272,7 +308,8 @@ class BattleSystem(commands.Cog):
                 (enemy_id,),
             )
             enemy = cursor.fetchone()
-            cursor.close(); conn.close()
+            cursor.close()
+            conn.close()
             logger.debug("Fetched enemy by id %s: %s", enemy_id, enemy)
             return enemy
         except Exception as e:
@@ -294,7 +331,8 @@ class BattleSystem(commands.Cog):
             (session.session_id, player_id),
         )
         trance = cursor.fetchone()
-        cursor.close(); conn.close()
+        cursor.close()
+        conn.close()
         if not trance:
             return
 
@@ -303,11 +341,13 @@ class BattleSystem(commands.Cog):
 
         session.trance_states[player_id] = {
             "trance_id": trance["trance_id"],
-            "name":      trance["trance_name"],
+            "name": trance["trance_name"],
             "remaining": trance["duration_turns"],
-            "max":       trance["duration_turns"],
+            "max": trance["duration_turns"],
         }
-        session.game_log.append(f"✨ <@{player_id}> has entered **{trance['trance_name']}**!")
+        session.game_log.append(
+            f"✨ <@{player_id}> has entered **{trance['trance_name']}**!"
+        )
 
     # --------------------------------------------------------------------- #
     #                     Cool‑down / session helpers                       #
@@ -316,7 +356,10 @@ class BattleSystem(commands.Cog):
         return ability.get("icon_url")
 
     def reduce_player_cooldowns(self, session: Any, player_id: int) -> None:
-        if not hasattr(session, "ability_cooldowns") or session.ability_cooldowns is None:
+        if (
+            not hasattr(session, "ability_cooldowns")
+            or session.ability_cooldowns is None
+        ):
             session.ability_cooldowns = {}
         cds = session.ability_cooldowns.get(player_id, {})
 
@@ -327,7 +370,8 @@ class BattleSystem(commands.Cog):
             (player_id, session.session_id),
         )
         player = cursor.fetchone()
-        cursor.close(); conn.close()
+        cursor.close()
+        conn.close()
         if not player:
             return
 
@@ -339,7 +383,8 @@ class BattleSystem(commands.Cog):
             (player["class_id"],),
         )
         class_data = cursor.fetchone()
-        cursor.close(); conn.close()
+        cursor.close()
+        conn.close()
 
         base = class_data["base_speed"] if class_data else 10
         multiplier = player_speed / base
@@ -355,7 +400,9 @@ class BattleSystem(commands.Cog):
             return None
         return mgr.get_session(channel_id)
 
-    def choose_enemy_ability(self, session: Any, enemy: Dict[str,Any]) -> Optional[Dict[str,Any]]:
+    def choose_enemy_ability(
+        self, session: Any, enemy: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
         """
         Pick one of this enemy’s abilities, respecting:
           – Silence status on enemy_effects
@@ -367,8 +414,10 @@ class BattleSystem(commands.Cog):
         eid = enemy["enemy_id"]
 
         # 1) If silenced, no spells at all
-        if any(eff.get("effect_name") == "Silence"
-               for eff in session.battle_state.get("enemy_effects", [])):
+        if any(
+            eff.get("effect_name") == "Silence"
+            for eff in session.battle_state.get("enemy_effects", [])
+        ):
             return None
 
         # 2) Decrement this enemy’s cooldowns by 1
@@ -380,8 +429,9 @@ class BattleSystem(commands.Cog):
 
         # 3) Load all enemy_abilities + ability metadata
         conn = self.db_connect()
-        cur  = conn.cursor(dictionary=True)
-        cur.execute("""
+        cur = conn.cursor(dictionary=True)
+        cur.execute(
+            """
             SELECT ea.ability_id, ea.weight,
                    ea.can_heal, ea.heal_threshold_pct,
                    ea.heal_amount_pct,
@@ -391,13 +441,16 @@ class BattleSystem(commands.Cog):
               FROM enemy_abilities ea
               JOIN abilities a USING (ability_id)
              WHERE ea.enemy_id = %s
-        """, (eid,))
+        """,
+            (eid,),
+        )
         rows = cur.fetchall()
-        cur.close(); conn.close()
+        cur.close()
+        conn.close()
 
         # 4) Filter out on‐cooldown & out‐of‐threshold heals
         pool = []
-        pct  = enemy["hp"] / enemy["max_hp"]
+        pct = enemy["hp"] / enemy["max_hp"]
         for r in rows:
             aid = r["ability_id"]
             if cds.get(aid, 0) > 0:
@@ -411,8 +464,8 @@ class BattleSystem(commands.Cog):
 
         # 5) Weighted random pick
         total = sum(r["weight"] for r in pool)
-        pick  = random.uniform(0, total)
-        upto  = 0.0
+        pick = random.uniform(0, total)
+        upto = 0.0
         for r in pool:
             upto += r["weight"]
             if pick <= upto:
@@ -428,16 +481,24 @@ class BattleSystem(commands.Cog):
     # --------------------------------------------------------------------- #
     #                           Battle sequence                             #
     # --------------------------------------------------------------------- #
-    async def handle_enemy_defeat(self, interaction: discord.Interaction, session: Any, enemy: dict) -> None:
+    async def handle_enemy_defeat(
+        self, interaction: discord.Interaction, session: Any, enemy: dict
+    ) -> None:
         gm = self.bot.get_cog("GameMaster")
         if gm:
-            gm.append_game_log(session.session_id, f"{enemy['enemy_name']} was defeated!")
+            gm.append_game_log(
+                session.session_id, f"{enemy['enemy_name']} was defeated!"
+            )
         xp = enemy.get("xp_reward", 0)
         if xp and gm:
             await gm.award_experience(session.current_turn, session.session_id, xp)
-        SessionPlayerModel.increment_enemies_defeated(session.session_id, session.current_turn)
+        SessionPlayerModel.increment_enemies_defeated(
+            session.session_id, session.current_turn
+        )
         if enemy.get("role") in ("boss", "miniboss"):
-            SessionPlayerModel.increment_bosses_defeated(session.session_id, session.current_turn)
+            SessionPlayerModel.increment_bosses_defeated(
+                session.session_id, session.current_turn
+            )
 
         conn = self.db_connect()
         cursor = conn.cursor(dictionary=True)
@@ -446,7 +507,8 @@ class BattleSystem(commands.Cog):
             (session.current_turn, session.session_id),
         )
         pd = cursor.fetchone()
-        cursor.close(); conn.close()
+        cursor.close()
+        conn.close()
 
         if pd:
             await self._replace_monster_room_with_safe(
@@ -464,10 +526,16 @@ class BattleSystem(commands.Cog):
                   AND r.coord_x = %s
                   AND r.coord_y = %s
                 """,
-                (session.session_id, pd["current_floor_id"], pd["coord_x"], pd["coord_y"]),
+                (
+                    session.session_id,
+                    pd["current_floor_id"],
+                    pd["coord_x"],
+                    pd["coord_y"],
+                ),
             )
             new_room = cursor.fetchone()
-            cursor.close(); conn.close()
+            cursor.close()
+            conn.close()
             if new_room:
                 session.game_state = new_room
 
@@ -495,19 +563,23 @@ class BattleSystem(commands.Cog):
         await self.display_victory_embed(interaction, session, enemy)
 
     async def start_battle(
-            self,
-            interaction: discord.Interaction,
-            player_id: int,
-            enemy: Dict[str, Any],
-            *,
-            previous_coords: Optional[Tuple[int, int, int]] = None
+        self,
+        interaction: discord.Interaction,
+        player_id: int,
+        enemy: Dict[str, Any],
+        *,
+        previous_coords: Optional[Tuple[int, int, int]] = None,
     ) -> None:
         mgr = self.bot.get_cog("SessionManager")
         if not mgr:
-            return await interaction.response.send_message("❌ SessionManager not available.", ephemeral=True)
+            return await interaction.response.send_message(
+                "❌ SessionManager not available.", ephemeral=True
+            )
         session = mgr.get_session(interaction.channel.id)
         if not session:
-            return await interaction.response.send_message("❌ No session found.", ephemeral=True)
+            return await interaction.response.send_message(
+                "❌ No session found.", ephemeral=True
+            )
 
         session.battle_state = {
             "enemy": enemy,
@@ -517,30 +589,24 @@ class BattleSystem(commands.Cog):
         }
 
         # 2) Load & normalize any buffs the player already had
-        raw_buffs = SessionPlayerModel.get_status_effects(
-            session.session_id,
-            player_id
-        )
+        raw_buffs = SessionPlayerModel.get_status_effects(session.session_id, player_id)
         session.battle_state["player_effects"] = [
-            self._normalize_se(raw_se)
-            for raw_se in raw_buffs
+            self._normalize_se(raw_se) for raw_se in raw_buffs
         ]
-    
-        enemy["gil_pool"]        = enemy.get("gil_drop", 0)
-        session.game_log         = ["Battle initiated!"]
-        session.current_enemy    = enemy
+
+        enemy["gil_pool"] = enemy.get("gil_drop", 0)
+        session.game_log = ["Battle initiated!"]
+        session.current_enemy = enemy
         # Start the ATB tick loop for this battle
         self.atb.start(session, self)
+
         def battle_log(sid: int, line: str):
             # 1) persist to your normal battle_log table via GameMaster
             self._append_battle_log(sid, line)
             # 2) append it _in memory_ so update_battle_embed will render it
             session.game_log.append(line)
 
-        session._status_engine = StatusEffectEngine(
-            session,
-            battle_log
-        )
+        session._status_engine = StatusEffectEngine(session, battle_log)
 
         conn = self.db_connect()
         cursor = conn.cursor(dictionary=True)
@@ -549,9 +615,12 @@ class BattleSystem(commands.Cog):
             (player_id, session.session_id),
         )
         player = cursor.fetchone()
-        cursor.close(); conn.close()
+        cursor.close()
+        conn.close()
 
-        player = self._apply_stat_modifiers(player, session.battle_state.get("player_effects", []))
+        player = self._apply_stat_modifiers(
+            player, session.battle_state.get("player_effects", [])
+        )
 
         self.embed_manager = self.embed_manager or self.bot.get_cog("EmbedManager")
         role = enemy.get("role", "normal")
@@ -565,54 +634,99 @@ class BattleSystem(commands.Cog):
         eb = discord.Embed(title=title, color=color)
         # show enemy HP + effects
         enemy_line = format_status_effects(session.battle_state["enemy_effects"])
-        val = f"❤️ HP: {self.create_bar(enemy['hp'], enemy['max_hp'])}"
+        enemy_val = f"❤️ HP: {self.create_bar(enemy['hp'], enemy['max_hp'])}"
         if enemy_line:
-            val += f" {enemy_line}"
-        eb.add_field(name=f"Enemy: {enemy['enemy_name']}", value=val, inline=False)
+            enemy_val += f" {enemy_line}"
+        enemy_val += f"\n⏳ ATB: {create_progress_bar(int(min(session.enemy_atb, 100)), 100, length=6)}"
+        eb.add_field(
+            name=f"Enemy: {enemy['enemy_name']}", value=enemy_val, inline=False
+        )
 
         # show player HP + effects
         player_line = format_status_effects(session.battle_state["player_effects"])
-        stats_text = f"❤️ HP: {self.create_bar(player['hp'], player['max_hp'])}"
+        player_val = f"❤️ HP: {self.create_bar(player['hp'], player['max_hp'])}"
         if player_line:
-            stats_text += f" {player_line}"
-        stats_text += f"\n⚔️ ATK: {player['attack_power']}\n🛡️ DEF: {player['defense']}"
-        eb.add_field(name="Your Stats", value=stats_text, inline=False)
+            player_val += f" {player_line}"
+        player_val += (
+            f"\n⚔️ ATK: {player['attack_power']}\n"
+            f"🛡️ DEF: {player['defense']}\n"
+            f"⏳ ATB: {create_progress_bar(int(min(session.atb_gauges.get(pid, 0), 100)), 100, length=6)}"
+        )
+        eb.add_field(name="Your Stats", value=player_val, inline=False)
 
-        eb.add_field(name="Battle Log",
-                     value="\n".join(session.game_log[-5:]) or "No actions recorded.",
-                     inline=False)
+        eb.add_field(
+            name="Battle Log",
+            value="\n".join(session.game_log[-5:]) or "No actions recorded.",
+            inline=False,
+        )
         if enemy.get("image_url"):
             eb.set_image(url=enemy["image_url"] + f"?t={int(time.time())}")
 
-        pid    = session.current_turn
+        pid = session.current_turn
         trance = getattr(session, "trance_states", {}).get(pid)
+        ready = session.is_ready(pid)
         if trance:
-            bar   = create_progress_bar(trance["remaining"], trance["max"], length=6)
+            bar = create_progress_bar(trance["remaining"], trance["max"], length=6)
             label = f"{trance['name']} {bar}"
             buttons = [
-                (label, discord.ButtonStyle.danger,   "combat_trance_menu", 0),
-                ("Skill", discord.ButtonStyle.primary, "combat_skill_menu",  0),
-                ("Use",   discord.ButtonStyle.success, "combat_item",        0),
-                ("Flee",  discord.ButtonStyle.secondary,"combat_flee",        0),
+                (label, discord.ButtonStyle.danger, "combat_trance_menu", 0, not ready),
+                (
+                    "Skill",
+                    discord.ButtonStyle.primary,
+                    "combat_skill_menu",
+                    0,
+                    not ready,
+                ),
+                ("Use", discord.ButtonStyle.success, "combat_item", 0, not ready),
+                ("Flee", discord.ButtonStyle.secondary, "combat_flee", 0, not ready),
             ]
         else:
             buttons = [
-                ("Attack", discord.ButtonStyle.danger,   "combat_attack",      0),
-                ("Skill",  discord.ButtonStyle.primary,  "combat_skill_menu",  0),
-                ("Use",    discord.ButtonStyle.success,  "combat_item",        0),
-                ("Flee",   discord.ButtonStyle.secondary,"combat_flee",        0),
+                ("Attack", discord.ButtonStyle.danger, "combat_attack", 0, not ready),
+                (
+                    "Skill",
+                    discord.ButtonStyle.primary,
+                    "combat_skill_menu",
+                    0,
+                    not ready,
+                ),
+                ("Use", discord.ButtonStyle.success, "combat_item", 0, not ready),
+                ("Flee", discord.ButtonStyle.secondary, "combat_flee", 0, not ready),
             ]
 
         await self.embed_manager.send_or_update_embed(
             interaction, title="", description="", embed_override=eb, buttons=buttons
         )
-        logger.debug("Battle started: %s vs %s", player_id, enemy["enemy_name"])
+
+    async def on_player_ready(self, session: Any, pid: int) -> None:
+        """Re-enable action buttons when a player's ATB gauge is full."""
+        enemy = session.current_enemy
+        if not enemy:
+            return
+
+        channel = self.bot.get_channel(int(session.thread_id))
+        if not channel:
+            try:
+                channel = await self.bot.fetch_channel(int(session.thread_id))
+            except Exception as e:  # pylint: disable=broad-except
+                logger.error("Failed to fetch channel for on_player_ready: %s", e)
+                return
+
+        class _FakeResponse:
+            def is_done(self) -> bool:
+                return True
+
+        class _FakeInteraction:
+            def __init__(self, ch: discord.abc.Messageable):
+                self.channel = ch
+                self.response = _FakeResponse()
+                self.followup = ch
+
+        fake = _FakeInteraction(channel)
+        await self.update_battle_embed(fake, pid, enemy)
 
     async def update_battle_embed(
-            self,
-            interaction: discord.Interaction,
-            player_id: int,
-            enemy: Dict[str, Any]
+        self, interaction: discord.Interaction, player_id: int, enemy: Dict[str, Any]
     ) -> None:
         mgr = self.bot.get_cog("SessionManager")
         if not mgr:
@@ -632,7 +746,8 @@ class BattleSystem(commands.Cog):
             (player_id, session.session_id),
         )
         player = cursor.fetchone()
-        cursor.close(); conn.close()
+        cursor.close()
+        conn.close()
 
         role = enemy.get("role", "normal")
         if role == "boss":
@@ -643,51 +758,73 @@ class BattleSystem(commands.Cog):
             title, color = "⚔️ Battle Mode", discord.Color.dark_red()
 
         eb = discord.Embed(title=title, color=color)
-        enemy_line  = format_status_effects(session.battle_state.get("enemy_effects", []))
-        val = f"❤️ HP: {self.create_bar(enemy['hp'], enemy['max_hp'])}"
-        if enemy_line:
-            val += f" {enemy_line}"
-        eb.add_field(name=f"Enemy: {enemy['enemy_name']}", value=val, inline=False)
-
-        player_line = format_status_effects(session.battle_state.get("player_effects", []))
-        stats_text = f"❤️ HP: {self.create_bar(player['hp'], player['max_hp'])}"
-        if player_line:
-            stats_text += f" {player_line}"
-        stats_text += (
-            f"\n⚔️ ATK: {player['attack_power']}\n"
-            f"🛡️ DEF: {player['defense']}"
+        enemy_line = format_status_effects(
+            session.battle_state.get("enemy_effects", [])
         )
-        eb.add_field(name="Your Stats", value=stats_text, inline=False)
+        enemy_val = f"❤️ HP: {self.create_bar(enemy['hp'], enemy['max_hp'])}"
+        if enemy_line:
+            enemy_val += f" {enemy_line}"
+        enemy_val += f"\n⏳ ATB: {create_progress_bar(int(min(session.enemy_atb, 100)), 100, length=6)}"
+        eb.add_field(
+            name=f"Enemy: {enemy['enemy_name']}", value=enemy_val, inline=False
+        )
 
-        eb.add_field(name="Battle Log",
-                     value="\n".join(session.game_log[-5:]) or "No actions recorded.",
-                     inline=False)
+        player_line = format_status_effects(
+            session.battle_state.get("player_effects", [])
+        )
+        player_val = f"❤️ HP: {self.create_bar(player['hp'], player['max_hp'])}"
+        if player_line:
+            player_val += f" {player_line}"
+        player_val += (
+            f"\n⚔️ ATK: {player['attack_power']}\n"
+            f"🛡️ DEF: {player['defense']}\n"
+            f"⏳ ATB: {create_progress_bar(int(min(session.atb_gauges.get(pid, 0), 100)), 100, length=6)}"
+        )
+        eb.add_field(name="Your Stats", value=player_val, inline=False)
+
+        eb.add_field(
+            name="Battle Log",
+            value="\n".join(session.game_log[-5:]) or "No actions recorded.",
+            inline=False,
+        )
         if enemy.get("image_url"):
             eb.set_image(url=enemy["image_url"] + f"?t={int(time.time())}")
 
-        pid    = session.current_turn
+        pid = session.current_turn
         trance = getattr(session, "trance_states", {}).get(pid)
+        ready = session.is_ready(pid)
         if trance:
-            bar   = create_progress_bar(trance["remaining"], trance["max"], length=6)
+            bar = create_progress_bar(trance["remaining"], trance["max"], length=6)
             label = f"{trance['name']} {bar}"
             buttons = [
-                (label, discord.ButtonStyle.danger,   "combat_trance_menu", 0),
-                ("Skill", discord.ButtonStyle.primary, "combat_skill_menu",  0),
-                ("Use",   discord.ButtonStyle.success, "combat_item",        0),
-                ("Flee",  discord.ButtonStyle.secondary,"combat_flee",        0),
+                (label, discord.ButtonStyle.danger, "combat_trance_menu", 0, not ready),
+                (
+                    "Skill",
+                    discord.ButtonStyle.primary,
+                    "combat_skill_menu",
+                    0,
+                    not ready,
+                ),
+                ("Use", discord.ButtonStyle.success, "combat_item", 0, not ready),
+                ("Flee", discord.ButtonStyle.secondary, "combat_flee", 0, not ready),
             ]
         else:
             buttons = [
-                ("Attack", discord.ButtonStyle.danger,   "combat_attack",      0),
-                ("Skill",  discord.ButtonStyle.primary,  "combat_skill_menu",  0),
-                ("Use",    discord.ButtonStyle.success,  "combat_item",        0),
-                ("Flee",   discord.ButtonStyle.secondary,"combat_flee",        0),
+                ("Attack", discord.ButtonStyle.danger, "combat_attack", 0, not ready),
+                (
+                    "Skill",
+                    discord.ButtonStyle.primary,
+                    "combat_skill_menu",
+                    0,
+                    not ready,
+                ),
+                ("Use", discord.ButtonStyle.success, "combat_item", 0, not ready),
+                ("Flee", discord.ButtonStyle.secondary, "combat_flee", 0, not ready),
             ]
 
         await self.embed_manager.send_or_update_embed(
             interaction, title="", description="", embed_override=eb, buttons=buttons
         )
-    
 
     async def handle_skill_menu(self, interaction: discord.Interaction) -> None:
         """
@@ -697,22 +834,29 @@ class BattleSystem(commands.Cog):
         mgr = self.bot.get_cog("SessionManager")
         embed_mgr = self.bot.get_cog("EmbedManager")
         if not mgr or not embed_mgr:
-            return await interaction.response.send_message("❌ SessionManager or EmbedManager unavailable.", ephemeral=True)
+            return await interaction.response.send_message(
+                "❌ SessionManager or EmbedManager unavailable.", ephemeral=True
+            )
         self.embed_manager = embed_mgr
 
         session = mgr.get_session(interaction.channel.id)
         if not session:
-            return await interaction.response.send_message("❌ No active session.", ephemeral=True)
+            return await interaction.response.send_message(
+                "❌ No active session.", ephemeral=True
+            )
 
         pid = session.current_turn
         in_battle = bool(session.battle_state) or self.is_elemental_challenge(session)
 
         # fetch class & level
         from models.session_models import SessionPlayerModel
+
         players = SessionPlayerModel.get_player_states(session.session_id)
         me = next((p for p in players if p["player_id"] == pid), None)
         if not me:
-            return await interaction.response.send_message("❌ Could not find your player data.", ephemeral=True)
+            return await interaction.response.send_message(
+                "❌ Could not find your player data.", ephemeral=True
+            )
         class_id, level = me["class_id"], me["level"]
 
         # load unlocked abilities
@@ -734,7 +878,8 @@ class BattleSystem(commands.Cog):
             (class_id, level),
         )
         abilities = await cur.fetchall()
-        await cur.close(); conn.close()
+        await cur.close()
+        conn.close()
 
         # filter by context
         allowed = {"self", "any"} | ({"enemy"} if in_battle else {"ally"})
@@ -744,14 +889,12 @@ class BattleSystem(commands.Cog):
         cds = session.ability_cooldowns.get(pid, {})
         for a in abilities:
             a["current_cooldown"] = cds.get(a["ability_id"], 0)
-        
+
         try:
             if not interaction.response.is_done():
                 await interaction.response.defer()
         except discord.errors.HTTPException as e:
-            logger.debug(
-                "Deferred interaction failed (already acknowledged): %s", e
-            )
+            logger.debug("Deferred interaction failed (already acknowledged): %s", e)
         await embed_mgr.send_skill_menu_embed(interaction, abilities)
 
     async def display_trance_menu(self, interaction: discord.Interaction) -> None:
@@ -761,17 +904,22 @@ class BattleSystem(commands.Cog):
         """
         session = self.get_session(interaction.channel.id)
         if not session:
-            return await interaction.response.send_message("❌ No session found.", ephemeral=True)
+            return await interaction.response.send_message(
+                "❌ No session found.", ephemeral=True
+            )
 
         pid = session.current_turn
         ts = getattr(session, "trance_states", {}).get(pid)
         if not ts:
-            return await interaction.response.send_message("❌ You have no active Trance.", ephemeral=True)
+            return await interaction.response.send_message(
+                "❌ You have no active Trance.", ephemeral=True
+            )
 
         # Load the abilities for this trance_id
         conn = self.db_connect()
         cursor = conn.cursor(dictionary=True)
-        cursor.execute("""
+        cursor.execute(
+            """
             SELECT ta.ability_id,
                    a.ability_name,
                    a.cooldown,
@@ -780,20 +928,23 @@ class BattleSystem(commands.Cog):
               JOIN abilities a USING (ability_id)
              WHERE ta.trance_id = %s
              ORDER BY ta.ability_id
-        """, (ts["trance_id"],))
+        """,
+            (ts["trance_id"],),
+        )
         abilities = cursor.fetchall()
-        cursor.close(); conn.close()
+        cursor.close()
+        conn.close()
 
         if not abilities:
-            return await interaction.response.send_message("⚠️ This Trance has no abilities.", ephemeral=True)
+            return await interaction.response.send_message(
+                "⚠️ This Trance has no abilities.", ephemeral=True
+            )
 
         try:
             if not interaction.response.is_done():
                 await interaction.response.defer()
         except discord.errors.HTTPException as e:
-            logger.debug(
-                "Deferred interaction failed (already acknowledged): %s", e
-            )
+            logger.debug("Deferred interaction failed (already acknowledged): %s", e)
 
         # Annotate cooldowns
         cds = session.ability_cooldowns.get(pid, {})
@@ -801,36 +952,58 @@ class BattleSystem(commands.Cog):
         for a in abilities:
             cd_now = int(cds.get(a["ability_id"], 0))
             bar = create_cooldown_bar(cd_now, a["cooldown"], length=6)
-            style = discord.ButtonStyle.secondary if cd_now > 0 else discord.ButtonStyle.primary
-            buttons.append((f"{a['ability_name']} {bar}", style, f"combat_trance_{a['ability_id']}", 0))
+            style = (
+                discord.ButtonStyle.secondary
+                if cd_now > 0
+                else discord.ButtonStyle.primary
+            )
+            buttons.append(
+                (
+                    f"{a['ability_name']} {bar}",
+                    style,
+                    f"combat_trance_{a['ability_id']}",
+                    0,
+                )
+            )
 
         # ← Back
-        buttons.append(("← Back", discord.ButtonStyle.secondary, "combat_trance_back", 0))
+        buttons.append(
+            ("← Back", discord.ButtonStyle.secondary, "combat_trance_back", 0)
+        )
 
         await self.embed_manager.send_or_update_embed(
             interaction,
             title=f"✨ {ts['name']} Abilities ({ts['remaining']} turns left)",
             description="Choose your Trance ability:",
-            buttons=buttons
+            buttons=buttons,
         )
 
-    async def handle_skill_use(self, interaction: discord.Interaction, ability_id: int) -> None:
+    async def handle_skill_use(
+        self, interaction: discord.Interaction, ability_id: int
+    ) -> None:
         mgr = self.bot.get_cog("SessionManager")
         if not mgr or not self.embed_manager:
-            return await interaction.response.send_message("❌ SessionManager or EmbedManager unavailable.", ephemeral=True)
+            return await interaction.response.send_message(
+                "❌ SessionManager or EmbedManager unavailable.", ephemeral=True
+            )
 
         session = mgr.get_session(interaction.channel.id)
         if not session:
-            return await interaction.response.send_message("❌ No active session.", ephemeral=True)
+            return await interaction.response.send_message(
+                "❌ No active session.", ephemeral=True
+            )
 
         # 1) fetch ability metadata up‑front so we know its target_type
         conn = self.db_connect()
         cur = conn.cursor(dictionary=True)
         cur.execute("SELECT * FROM abilities WHERE ability_id = %s", (ability_id,))
         ability_meta = cur.fetchone()
-        cur.close(); conn.close()
+        cur.close()
+        conn.close()
         if not ability_meta:
-            return await interaction.response.send_message("❌ Ability not found.", ephemeral=True)
+            return await interaction.response.send_message(
+                "❌ Ability not found.", ephemeral=True
+            )
 
         # Cooldown check
         pid = session.current_turn
@@ -842,7 +1015,9 @@ class BattleSystem(commands.Cog):
 
         challenge = session.game_state.get("illusion_challenge")
         if challenge and challenge.get("type") == "elemental_crystal":
-            session.ability_cooldowns.setdefault(pid, {})[ability_id] = ability_meta.get("cooldown", 0)
+            session.ability_cooldowns.setdefault(pid, {})[ability_id] = (
+                ability_meta.get("cooldown", 0)
+            )
             gm = self.bot.get_cog("GameMaster")
             if gm:
                 await gm.handle_illusion_crystal_skill(interaction, ability_meta)
@@ -865,7 +1040,6 @@ class BattleSystem(commands.Cog):
         pid = session.current_turn
         enemy = session.current_enemy if session.current_enemy else None
 
-
         # 2) fetch player stats
         conn = self.db_connect()
         cur = conn.cursor(dictionary=True)
@@ -874,24 +1048,28 @@ class BattleSystem(commands.Cog):
             (pid, session.session_id),
         )
         player = cur.fetchone()
-        cur.close(); conn.close()
+        cur.close()
+        conn.close()
         if not player:
-            return await interaction.response.send_message("❌ Could not retrieve your stats.", ephemeral=True)
+            return await interaction.response.send_message(
+                "❌ Could not retrieve your stats.", ephemeral=True
+            )
 
         try:
             if not interaction.response.is_done():
                 await interaction.response.defer()
         except discord.errors.HTTPException as e:
-            logger.debug(
-                "Deferred interaction failed (already acknowledged): %s", e
-            )
-
+            logger.debug("Deferred interaction failed (already acknowledged): %s", e)
 
         # 3) resolve via AbilityEngine
         # if we’re outside battle, treat the player as the “target” for self‑buffs/heals
-        player_mod = self._apply_stat_modifiers(player, session.battle_state.get("player_effects", []))
+        player_mod = self._apply_stat_modifiers(
+            player, session.battle_state.get("player_effects", [])
+        )
         if enemy is not None:
-            enemy_mod = self._apply_stat_modifiers(enemy, session.battle_state.get("enemy_effects", []))
+            enemy_mod = self._apply_stat_modifiers(
+                enemy, session.battle_state.get("enemy_effects", [])
+            )
         else:
             enemy_mod = player_mod
         engine_target = enemy_mod if enemy is not None else player_mod
@@ -909,42 +1087,46 @@ class BattleSystem(commands.Cog):
             # 2) normalize, merge & persist each new buff exactly once
             # ─── load any existing buffs from the DB into memory ───────────
             if "player_effects" not in session.battle_state:
-                raw_saved = SessionPlayerModel.get_status_effects(session.session_id, pid)
+                raw_saved = SessionPlayerModel.get_status_effects(
+                    session.session_id, pid
+                )
                 session.battle_state["player_effects"] = [
                     self._normalize_se(raw) for raw in raw_saved
                 ]
             buffs = session.battle_state["player_effects"]
-        
+
             # ─── merge in any newly returned status effects ───────────────
             for raw_se in result.status_effects or []:
                 se = self._normalize_se(raw_se)
                 # only add if it isn’t already in our list (by effect_id)
-                if not any(existing.get("effect_id") == se.get("effect_id") for existing in buffs):
+                if not any(
+                    existing.get("effect_id") == se.get("effect_id")
+                    for existing in buffs
+                ):
                     buffs.append(se)
-        
-            # ─── write the full, deduped list back to the DB ─────────────
-            SessionPlayerModel.update_status_effects(
-                session.session_id,
-                pid,
-                buffs
-            )
 
+            # ─── write the full, deduped list back to the DB ─────────────
+            SessionPlayerModel.update_status_effects(session.session_id, pid, buffs)
 
             # 3) if it healed you immediately, also log that
             if result.type in ("heal", "set_hp"):
                 old_hp = self._get_player_hp(pid, session.session_id)
-                new_hp = (result.amount
-                        if result.type == "set_hp"
-                        else min(old_hp + result.amount,
-                                self._get_player_max_hp(pid, session.session_id)))
+                new_hp = (
+                    result.amount
+                    if result.type == "set_hp"
+                    else min(
+                        old_hp + result.amount,
+                        self._get_player_max_hp(pid, session.session_id),
+                    )
+                )
                 self._update_player_hp(pid, session.session_id, new_hp)
-                gm.append_game_log(session.session_id, f"You are healed to {new_hp} HP.")
+                gm.append_game_log(
+                    session.session_id, f"You are healed to {new_hp} HP."
+                )
 
             # 4) redraw the room embed (old lines stay intact, new ones are appended)
             sm = self.bot.get_cog("SessionManager")
             return await sm.refresh_current_state(interaction)
-
-        
 
         # 4) Emit exactly one log line per result.type, or fall back on engine.logs for niche cases
         if result.type == "damage":
@@ -992,7 +1174,8 @@ class BattleSystem(commands.Cog):
                     SessionPlayerModel.update_status_effects(
                         session.session_id,
                         pid,
-                        session.battle_state.get("player_effects", []) + result.status_effects
+                        session.battle_state.get("player_effects", [])
+                        + result.status_effects,
                     )
 
                 # 2) If this skill also heals immediately on use, write that to the DB now:
@@ -1000,15 +1183,21 @@ class BattleSystem(commands.Cog):
                     # e.g. “heal” gives you result.amount HP
                     # or “set_hp” forces to exactly result.amount
                     old_hp = self._get_player_hp(pid, session.session_id)
-                    new_hp = result.amount if result.type == "set_hp" else min(
-                        old_hp + result.amount,
-                        self._get_player_max_hp(pid, session.session_id)
+                    new_hp = (
+                        result.amount
+                        if result.type == "set_hp"
+                        else min(
+                            old_hp + result.amount,
+                            self._get_player_max_hp(pid, session.session_id),
+                        )
                     )
                     self._update_player_hp(pid, session.session_id, new_hp)
                     session.game_log.append(f"You are healed to {new_hp} HP.")
 
                 # 3) Send the same ephemeral confirmation you already build in game_log
-                await interaction.followup.send("\n".join(session.game_log), ephemeral=True)
+                await interaction.followup.send(
+                    "\n".join(session.game_log), ephemeral=True
+                )
 
                 # 4) Finally—*after* writing to the DB— redraw the *room* (not the battle embed)
                 #    so your room embed updates with your new HP and buttons.
@@ -1016,16 +1205,18 @@ class BattleSystem(commands.Cog):
                 return await sm.refresh_current_state(interaction)
 
         await self.update_battle_embed(interaction, pid, enemy)
-        if result.type in ("damage","dot") and enemy["hp"] <= 0:
+        if result.type in ("damage", "dot") and enemy["hp"] <= 0:
             return await self.handle_enemy_defeat(interaction, session, enemy)
-
 
         # 5) apply any returned status effects
         for raw_se in getattr(result, "status_effects", []) or []:
             raw_se.setdefault("target", ability_meta.get("target_type", "self"))
             se = self._normalize_se(raw_se)
             bucket = "player_effects" if se["target"] == "self" else "enemy_effects"
-            if not any(e.get("effect_name") == se.get("effect_name") for e in session.battle_state[bucket]):
+            if not any(
+                e.get("effect_name") == se.get("effect_name")
+                for e in session.battle_state[bucket]
+            ):
                 session.battle_state[bucket].append(se)
 
             # initial application log
@@ -1044,20 +1235,24 @@ class BattleSystem(commands.Cog):
                 )
 
         # 6) burn cooldown on the player
-        session.ability_cooldowns.setdefault(pid, {})[ability_id] = ability_meta.get("cooldown", 0)
+        session.ability_cooldowns.setdefault(pid, {})[ability_id] = ability_meta.get(
+            "cooldown", 0
+        )
         self.reduce_player_cooldowns(session, pid)
 
         # 7) handle the result types
-        if result.type in ("damage","heal","set_hp","dot","hot"):
+        if result.type in ("damage", "heal", "set_hp", "dot", "hot"):
             # update enemy.hp or player.hp as needed
             if result.type == "damage":
                 enemy["hp"] = max(enemy["hp"] - result.amount, 0)
             elif result.type == "heal":
-                if target in ("self","ally"):
+                if target in ("self", "ally"):
                     # heal the player
                     new_hp = min(player["hp"] + result.amount, player["max_hp"])
                     self._update_player_hp(pid, session.session_id, new_hp)
-                    session.game_log.append(f"You restore {result.amount} HP to yourself!")
+                    session.game_log.append(
+                        f"You restore {result.amount} HP to yourself!"
+                    )
                 else:
                     # heal the enemy (e.g. Vampire or enemy‑buff)
                     enemy["hp"] = min(enemy["hp"] + result.amount, enemy["max_hp"])
@@ -1071,36 +1266,40 @@ class BattleSystem(commands.Cog):
             elif result.type == "dot":
                 pass  # handled above
             elif result.type == "hot":
-                bucket = "player_effects" if target in ("self","ally") else "enemy_effects"
+                bucket = (
+                    "player_effects" if target in ("self", "ally") else "enemy_effects"
+                )
                 session.battle_state[bucket].append(result.dot)
                 if bucket == "player_effects":
-                    new_hp = min(player["hp"] + result.dot["heal_per_turn"], player["max_hp"])
+                    new_hp = min(
+                        player["hp"] + result.dot["heal_per_turn"], player["max_hp"]
+                    )
                     self._update_player_hp(pid, session.session_id, new_hp)
                     session.game_log.append(
                         f"You regain {result.dot['heal_per_turn']} HP from {result.dot['effect_name']}."
                     )
                 else:
-                    enemy["hp"] = min(enemy["hp"] + result.dot["heal_per_turn"], enemy["max_hp"])
+                    enemy["hp"] = min(
+                        enemy["hp"] + result.dot["heal_per_turn"], enemy["max_hp"]
+                    )
                     session.game_log.append(
                         f"{enemy['enemy_name']} regenerates {result.dot['heal_per_turn']} HP."
                     )
 
-
         else:
             # for “miss”, “pilfer”, “mug”, etc.
             await self.update_battle_embed(interaction, pid, enemy)
-            if result.type in ("pilfer","mug") and result.type=="pilfer":
+            if result.type in ("pilfer", "mug") and result.type == "pilfer":
                 # apply gil steal on DB
                 self._steal_gil(pid, session.session_id, result.amount)
                 enemy["gil_pool"] -= result.amount
-            if result.type=="mug":
+            if result.type == "mug":
                 enemy["hp"] = max(enemy["hp"] - result.amount, 0)
                 if enemy["hp"] <= 0:
                     return await self.handle_enemy_defeat(interaction, session, enemy)
-        
+
         if enemy["hp"] <= 0:
             return await self.handle_enemy_defeat(interaction, session, enemy)
-
 
         adv = self._check_speed_advantage(session, player, enemy)
         if adv == "player":
@@ -1115,8 +1314,10 @@ class BattleSystem(commands.Cog):
     # --------------------------------------------------------------------- #
     #                          Enemy –> Player turn                         #
     # --------------------------------------------------------------------- #
-    
-    async def enemy_turn(self, interaction: discord.Interaction, enemy: Dict[str, Any]) -> None:
+
+    async def enemy_turn(
+        self, interaction: discord.Interaction, enemy: Dict[str, Any]
+    ) -> None:
         mgr = self.bot.get_cog("SessionManager")
         if not mgr:
             return
@@ -1124,9 +1325,13 @@ class BattleSystem(commands.Cog):
         if not session:
             return
         # if battle is over (enemy cleared out), don't keep looping
-        if not session.battle_state or session.current_enemy is None or session.current_enemy.get("hp", 0) <= 0:
+        if (
+            not session.battle_state
+            or session.current_enemy is None
+            or session.current_enemy.get("hp", 0) <= 0
+        ):
             return
-        
+
         # 1) tick all enemy effects for this turn
         await session._status_engine.tick_combat("enemy")
         if enemy["hp"] <= 0:
@@ -1144,20 +1349,26 @@ class BattleSystem(commands.Cog):
             (pid, session.session_id),
         )
         player = cursor.fetchone()
-        cursor.close(); conn.close()
+        cursor.close()
+        conn.close()
 
         # 3) pick an ability (or None)
         ability = self.choose_enemy_ability(session, enemy)
 
         # 4) fallback to plain attack
         if not ability:
-            enemy_mod = self._apply_stat_modifiers(enemy, session.battle_state.get("enemy_effects", []))
-            player_mod = self._apply_stat_modifiers(player, session.battle_state.get("player_effects", []))
+            enemy_mod = self._apply_stat_modifiers(
+                enemy, session.battle_state.get("enemy_effects", [])
+            )
+            player_mod = self._apply_stat_modifiers(
+                player, session.battle_state.get("player_effects", [])
+            )
             dmg = self.ability.jrpg_damage(
-                enemy_mod, player_mod,
+                enemy_mod,
+                player_mod,
                 base_damage=0,
                 scaling_stat="attack_power",
-                scaling_factor=1.0
+                scaling_factor=1.0,
             )
             session.game_log.append(f"{enemy['enemy_name']} attacks for {dmg} damage!")
             new_hp = max(player["hp"] - dmg, 0)
@@ -1168,8 +1379,12 @@ class BattleSystem(commands.Cog):
             return await self._end_enemy_action(interaction)
 
         # 5) otherwise resolve the chosen ability
-        enemy_mod = self._apply_stat_modifiers(enemy, session.battle_state.get("enemy_effects", []))
-        player_mod = self._apply_stat_modifiers(player, session.battle_state.get("player_effects", []))
+        enemy_mod = self._apply_stat_modifiers(
+            enemy, session.battle_state.get("enemy_effects", [])
+        )
+        player_mod = self._apply_stat_modifiers(
+            player, session.battle_state.get("player_effects", [])
+        )
         result = self.ability.resolve(enemy_mod, player_mod, ability)
 
         # 6) apply any status effects first (e.g. enemy‐inflicted DoT/HoT)
@@ -1240,7 +1455,10 @@ class BattleSystem(commands.Cog):
         if result.type == "damage":
             dmg = result.amount
             # barrier check
-            if any(b["effect_name"] == "Barrier" for b in session.battle_state["player_effects"]):
+            if any(
+                b["effect_name"] == "Barrier"
+                for b in session.battle_state["player_effects"]
+            ):
                 dmg //= 2
                 session.game_log.append("🛡️ Barrier halves the incoming damage!")
             new_hp = max(player["hp"] - dmg, 0)
@@ -1277,8 +1495,6 @@ class BattleSystem(commands.Cog):
         await self.update_battle_embed(interaction, pid, enemy)
         return await self._end_enemy_action(interaction)
 
-
-
     async def handle_attack(self, interaction: discord.Interaction) -> None:
         mgr = self.bot.get_cog("SessionManager")
         if not mgr or not self.embed_manager:
@@ -1294,20 +1510,26 @@ class BattleSystem(commands.Cog):
             return
 
         session = mgr.get_session(interaction.channel.id)
-        if not session or not session.battle_state or not session.battle_state.get("enemy"):
+        if (
+            not session
+            or not session.battle_state
+            or not session.battle_state.get("enemy")
+        ):
             if not interaction.response.is_done():
-                await interaction.response.send_message("❌ No active battle found.", ephemeral=True)
+                await interaction.response.send_message(
+                    "❌ No active battle found.", ephemeral=True
+                )
             else:
-                await interaction.followup.send("❌ No active battle found.", ephemeral=True)
+                await interaction.followup.send(
+                    "❌ No active battle found.", ephemeral=True
+                )
             return
 
         try:
             if not interaction.response.is_done():
                 await interaction.response.defer()
         except discord.errors.HTTPException as e:
-            logger.debug(
-                "Deferred interaction failed (already acknowledged): %s", e
-            )
+            logger.debug("Deferred interaction failed (already acknowledged): %s", e)
 
         enemy = session.current_enemy
         pid = session.current_turn
@@ -1318,10 +1540,19 @@ class BattleSystem(commands.Cog):
             (pid, session.session_id),
         )
         player = cursor.fetchone()
-        cursor.close(); conn.close()
-        dmg = self.ability.jrpg_damage(player, enemy, base_damage=0, scaling_stat="attack_power", scaling_factor=1.0)
+        cursor.close()
+        conn.close()
+        dmg = self.ability.jrpg_damage(
+            player,
+            enemy,
+            base_damage=0,
+            scaling_stat="attack_power",
+            scaling_factor=1.0,
+        )
         enemy["hp"] = max(enemy["hp"] - dmg, 0)
-        session.game_log.append(f"You strike the {enemy['enemy_name']} for {dmg} damage!")
+        session.game_log.append(
+            f"You strike the {enemy['enemy_name']} for {dmg} damage!"
+        )
         self.reduce_player_cooldowns(session, pid)
 
         if enemy["hp"] <= 0:
@@ -1344,16 +1575,24 @@ class BattleSystem(commands.Cog):
     # --------------------------------------------------------------------- #
     #                            Victory embed                              #
     # --------------------------------------------------------------------- #
-    async def display_victory_embed(self, interaction: discord.Interaction, session: Any, enemy: dict) -> None:
+    async def display_victory_embed(
+        self, interaction: discord.Interaction, session: Any, enemy: dict
+    ) -> None:
         reward_text = await self.award_loot(session, enemy)
         eb = discord.Embed(title="Victory!", color=discord.Color.gold())
         if enemy.get("image_url"):
             eb.set_image(url=enemy["image_url"] + f"?t={int(time.time())}")
         recent = session.game_log[-5:]
-        eb.add_field(name="Battle Log", value="\n".join(recent) or "No actions recorded.", inline=False)
+        eb.add_field(
+            name="Battle Log",
+            value="\n".join(recent) or "No actions recorded.",
+            inline=False,
+        )
         eb.add_field(name="Rewards", value=reward_text, inline=False)
         btns = [("Continue", discord.ButtonStyle.primary, "battle_victory_continue", 0)]
-        await self.embed_manager.send_or_update_embed(interaction, title="", description="", embed_override=eb, buttons=btns)
+        await self.embed_manager.send_or_update_embed(
+            interaction, title="", description="", embed_override=eb, buttons=btns
+        )
 
     # --------------------------------------------------------------------- #
     #                              Loot / XP                                #
@@ -1380,7 +1619,9 @@ class BattleSystem(commands.Cog):
         else:
             drops = []
         if item_id:
-            drops.append({"item_id": item_id, "drop_chance": 1.0, "min_qty": qty, "max_qty": qty})
+            drops.append(
+                {"item_id": item_id, "drop_chance": 1.0, "min_qty": qty, "max_qty": qty}
+            )
 
         awards: Dict[int, int] = {}
         for d in drops:
@@ -1388,7 +1629,10 @@ class BattleSystem(commands.Cog):
                 n = random.randint(d["min_qty"], d["max_qty"])
                 awards[d["item_id"]] = awards.get(d["item_id"], 0) + n
 
-        cursor.execute("SELECT gil, inventory FROM players WHERE player_id = %s AND session_id = %s", (pid, sid))
+        cursor.execute(
+            "SELECT gil, inventory FROM players WHERE player_id = %s AND session_id = %s",
+            (pid, sid),
+        )
         pd = cursor.fetchone()
         if pd:
             new_gil = pd["gil"] + gil
@@ -1407,7 +1651,8 @@ class BattleSystem(commands.Cog):
             if gil:
                 SessionPlayerModel.add_gil_earned(sid, pid, gil)
 
-        cursor.close(); conn.close()
+        cursor.close()
+        conn.close()
         return "\n".join(lines) if lines else "No rewards."
 
     # --------------------------------------------------------------------- #
@@ -1424,11 +1669,13 @@ class BattleSystem(commands.Cog):
         if inv:
             return await inv.display_use_item_menu(interaction)
         else:
-            await interaction.response.send_message("❌ Inventory system not available.", ephemeral=True)
+            await interaction.response.send_message(
+                "❌ Inventory system not available.", ephemeral=True
+            )
 
     async def handle_flee(self, interaction: discord.Interaction) -> None:
         mgr = self.bot.get_cog("SessionManager")
-        gm  = self.bot.get_cog("GameMaster")
+        gm = self.bot.get_cog("GameMaster")
         if not mgr or not gm or not self.embed_manager:
             return await interaction.response.send_message(
                 "❌ SessionManager, GameMaster or EmbedManager not available.",
@@ -1436,15 +1683,15 @@ class BattleSystem(commands.Cog):
             )
         session = mgr.get_session(interaction.channel.id)
         if not session:
-            return await interaction.response.send_message("❌ No active session found.", ephemeral=True)
+            return await interaction.response.send_message(
+                "❌ No active session found.", ephemeral=True
+            )
 
         try:
             if not interaction.response.is_done():
                 await interaction.response.defer()
         except discord.errors.HTTPException as e:
-            logger.debug(
-                "Deferred interaction failed (already acknowledged): %s", e
-            )
+            logger.debug("Deferred interaction failed (already acknowledged): %s", e)
 
         prev = None
         if session.battle_state:
@@ -1508,7 +1755,11 @@ class BattleSystem(commands.Cog):
                     pos = cur.fetchone()
                 conn.close()
                 if pos:
-                    x, y, floor = pos["coord_x"], pos["coord_y"], pos["current_floor_id"]
+                    x, y, floor = (
+                        pos["coord_x"],
+                        pos["coord_y"],
+                        pos["current_floor_id"],
+                    )
                     conn = self.db_connect()
                     with conn.cursor() as cur:
                         cur.execute(
@@ -1540,24 +1791,34 @@ class BattleSystem(commands.Cog):
             return
         if cid == "combat_trance_back":
             if session and session.current_enemy:
-                return await self.update_battle_embed(interaction, session.current_turn, session.current_enemy)
+                return await self.update_battle_embed(
+                    interaction, session.current_turn, session.current_enemy
+                )
             return
-        if session and session.current_enemy and session.current_turn != interaction.user.id:
+        if (
+            session
+            and session.current_enemy
+            and session.current_turn != interaction.user.id
+        ):
             return
         if cid.startswith("combat_skill_") and cid != "combat_skill_back":
-           aid = int(cid.split("_", 2)[2])
-           # fetch its target_type
-           conn = self.db_connect()
-           cur  = conn.cursor(dictionary=True)
-           cur.execute("SELECT target_type FROM abilities WHERE ability_id=%s", (aid,))
-           meta = cur.fetchone()
-           cur.close(); conn.close()
-           # allow “self” or “any” outside battle
-           if meta and meta["target_type"] in ("self", "any") and not (session and session.current_enemy):
-               return await self.handle_skill_use(interaction, aid)
-           # otherwise fall back
-           return await self.handle_skill_use(interaction, aid)
-        
+            aid = int(cid.split("_", 2)[2])
+            # fetch its target_type
+            conn = self.db_connect()
+            cur = conn.cursor(dictionary=True)
+            cur.execute("SELECT target_type FROM abilities WHERE ability_id=%s", (aid,))
+            meta = cur.fetchone()
+            cur.close()
+            conn.close()
+            # allow “self” or “any” outside battle
+            if (
+                meta
+                and meta["target_type"] in ("self", "any")
+                and not (session and session.current_enemy)
+            ):
+                return await self.handle_skill_use(interaction, aid)
+            # otherwise fall back
+            return await self.handle_skill_use(interaction, aid)
 
         try:
             if cid == "combat_trance_menu":
@@ -1567,7 +1828,9 @@ class BattleSystem(commands.Cog):
                 return await self.handle_skill_use(interaction, aid)
             if cid == "combat_skill_back":
                 if session and session.current_enemy:
-                    return await self.update_battle_embed(interaction, session.current_turn, session.current_enemy)
+                    return await self.update_battle_embed(
+                        interaction, session.current_turn, session.current_enemy
+                    )
                 else:
                     return await mgr.refresh_current_state(interaction)
             if cid == "combat_attack":
@@ -1575,8 +1838,12 @@ class BattleSystem(commands.Cog):
             if cid == "combat_flee":
                 return await self.handle_flee(interaction)
         except Exception as e:
-            logger.error("Error handling combat interaction '%s': %s", cid, e, exc_info=True)
-            await interaction.followup.send("❌ An error occurred processing battle action.", ephemeral=True)
+            logger.error(
+                "Error handling combat interaction '%s': %s", cid, e, exc_info=True
+            )
+            await interaction.followup.send(
+                "❌ An error occurred processing battle action.", ephemeral=True
+            )
 
     # --------------------------------------------------------------------- #
     #                   Embed helpers for other states                      #
@@ -1589,15 +1856,21 @@ class BattleSystem(commands.Cog):
         enemy_max_hp: Optional[int] = None,
     ) -> None:
         title = "⚔️ You are in battle..."
-        desc = f"A {enemy_name} appears!\nHP: {enemy_hp}/{enemy_max_hp}" if enemy_name else "Choose your action!"
+        desc = (
+            f"A {enemy_name} appears!\nHP: {enemy_hp}/{enemy_max_hp}"
+            if enemy_name
+            else "Choose your action!"
+        )
         buttons = [
             ("Attack", discord.ButtonStyle.danger, "combat_attack", 0),
-            ("Skill",  discord.ButtonStyle.primary, "combat_skill_menu", 0),
-            ("Use",    discord.ButtonStyle.success, "combat_item", 0),
-            ("Flee",   discord.ButtonStyle.secondary, "combat_flee", 0),
-            ("Menu",   discord.ButtonStyle.secondary, "action_menu", 0),
+            ("Skill", discord.ButtonStyle.primary, "combat_skill_menu", 0),
+            ("Use", discord.ButtonStyle.success, "combat_item", 0),
+            ("Flee", discord.ButtonStyle.secondary, "combat_flee", 0),
+            ("Menu", discord.ButtonStyle.secondary, "action_menu", 0),
         ]
-        await self.embed_manager.send_or_update_embed(interaction, title, desc, buttons=buttons)
+        await self.embed_manager.send_or_update_embed(
+            interaction, title, desc, buttons=buttons
+        )
 
     async def send_inventory_menu(self, interaction: discord.Interaction) -> None:
         title, desc = "🎒 Your Inventory", "Choose an item to use in battle."
@@ -1605,9 +1878,15 @@ class BattleSystem(commands.Cog):
         cursor = conn.cursor(dictionary=True)
         cursor.execute("SELECT item_name, item_id FROM items")
         items = cursor.fetchall()
-        cursor.close(); conn.close()
-        buttons = [(it["item_name"], discord.ButtonStyle.primary, f"item_{it['item_id']}", 0) for it in items]
-        await self.embed_manager.send_or_update_embed(interaction, title, desc, buttons=buttons)
+        cursor.close()
+        conn.close()
+        buttons = [
+            (it["item_name"], discord.ButtonStyle.primary, f"item_{it['item_id']}", 0)
+            for it in items
+        ]
+        await self.embed_manager.send_or_update_embed(
+            interaction, title, desc, buttons=buttons
+        )
 
     async def send_npc_shop_embed(
         self,
@@ -1620,11 +1899,13 @@ class BattleSystem(commands.Cog):
         title = f"Shop: {vendor_name}"
         desc = f"{dialogue}\n\n**Your Gil:** {player_currency}"
         buttons = [
-            ("Buy",  discord.ButtonStyle.primary, "shop_buy_menu", 0),
+            ("Buy", discord.ButtonStyle.primary, "shop_buy_menu", 0),
             ("Sell", discord.ButtonStyle.primary, "shop_sell_menu", 0),
             ("Back", discord.ButtonStyle.secondary, "shop_back_main", 0),
         ]
-        await self.embed_manager.send_or_update_embed(interaction, title, desc, image_url=image_url, buttons=buttons)
+        await self.embed_manager.send_or_update_embed(
+            interaction, title, desc, image_url=image_url, buttons=buttons
+        )
 
     async def send_or_update_embed(
         self,
@@ -1665,7 +1946,8 @@ class BattleSystem(commands.Cog):
             (new_hp, player_id, session_id),
         )
         conn.commit()
-        cur.close(); conn.close()
+        cur.close()
+        conn.close()
 
     def _steal_gil(self, player_id: int, session_id: int, amount: int):
         conn = self.db_connect()
@@ -1675,26 +1957,33 @@ class BattleSystem(commands.Cog):
             (amount, player_id, session_id),
         )
         conn.commit()
-        cur.close(); conn.close()
+        cur.close()
+        conn.close()
         SessionPlayerModel.add_gil_earned(session_id, player_id, amount)
 
     # ─── New: fetch current & max HP for DoT/HoT ─────────────────────────
     def _get_player_hp(self, player_id: int, session_id: int) -> int:
         conn = self.db_connect()
         cur = conn.cursor()
-        cur.execute("SELECT hp FROM players WHERE player_id=%s AND session_id=%s",
-                    (player_id, session_id))
+        cur.execute(
+            "SELECT hp FROM players WHERE player_id=%s AND session_id=%s",
+            (player_id, session_id),
+        )
         row = cur.fetchone()
-        cur.close(); conn.close()
+        cur.close()
+        conn.close()
         return row[0] if row else 0
 
     def _get_player_max_hp(self, player_id: int, session_id: int) -> int:
         conn = self.db_connect()
         cur = conn.cursor()
-        cur.execute("SELECT max_hp FROM players WHERE player_id=%s AND session_id=%s",
-                    (player_id, session_id))
+        cur.execute(
+            "SELECT max_hp FROM players WHERE player_id=%s AND session_id=%s",
+            (player_id, session_id),
+        )
         row = cur.fetchone()
-        cur.close(); conn.close()
+        cur.close()
+        conn.close()
         return row[0] if row else 0
 
     async def _kill_player(self, interaction, pid, session):
@@ -1732,14 +2021,19 @@ class BattleSystem(commands.Cog):
                 (session.current_turn, session.session_id),
             )
             row = cur.fetchone()
-            cur.close(); conn.close()
+            cur.close()
+            conn.close()
             player_stats = {"speed": row["speed"] if row else 0}
-            adv = self._check_speed_advantage(session, player_stats, session.current_enemy)
+            adv = self._check_speed_advantage(
+                session, player_stats, session.current_enemy
+            )
             if adv == "enemy":
                 session.game_log.append(
                     f"{session.current_enemy.get('enemy_name', 'The enemy')} strikes again due to speed!"
                 )
-                await self.update_battle_embed(interaction, session.current_turn, session.current_enemy)
+                await self.update_battle_embed(
+                    interaction, session.current_turn, session.current_enemy
+                )
                 await asyncio.sleep(1)
                 return await self.enemy_turn(interaction, session.current_enemy)
 


### PR DESCRIPTION
## Summary
- show ATB gauges for player and enemy using progress bars
- disable combat buttons until ATB is ready
- add callback to re-enable buttons when gauge fills

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685546e83be083289169ed76dc14ee5e