### PR TITLE
Ensure battle cleanup resets ATB state

### DIFF
--- a/core/game_session.py
+++ b/core/game_session.py
@@ -153,6 +153,9 @@ class GameSession:
         """Reset all stored data about the current battle."""
         self.battle_state = None
         self.current_enemy = None
+        self.atb_gauges = {}
+        self.enemy_atb = 0.0
+        self.atb_task = None
 
     def update_ability_cooldown(self, player_id: int, ability_id: int, cd: float) -> None:
         """Set the cooldown timer for a player's ability."""

--- a/game/battle_system.py
+++ b/game/battle_system.py
@@ -2005,7 +2005,11 @@ class BattleSystem(commands.Cog):
         # 3) re‐draw the battle embed (now at 0 HP) before dropping in the death panel
         await self.update_battle_embed(interaction, pid, session.current_enemy)
 
-        # 4) finally hand off to SessionManager/GameMaster to render the “💀 You have fallen” embed
+        # 4) teardown combat state and stop ATB
+        session.clear_battle_state()
+        self.atb.stop(session.session_id)
+
+        # 5) finally hand off to SessionManager/GameMaster to render the “💀 You have fallen” embed
         sm = self.bot.get_cog("SessionManager")
         return await sm.refresh_current_state(interaction)
 


### PR DESCRIPTION
## Summary
- stop ATB when killing a player and clearing battle state
- wipe ATB gauges and task when clearing battle state

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68554c24c59c832884bae35e9dd26bac