### PR TITLE
Fix ATB gauge handling and speed bonuses

### DIFF
--- a/core/game_session.py
+++ b/core/game_session.py
@@ -79,6 +79,8 @@ class GameSession:
         self.atb_gauges: Dict[int, float] = {}
         self.enemy_atb: float = 0.0
         self.atb_task: Optional[asyncio.Task] = None
+        # Limit speed-based extra turns to one until the next enemy action
+        self.speed_bonus_used: bool = False
         # ── status effects ───────────────────────────────────────────────
         # { player_id: [ { "effect_id": int, "remaining": int }, … ] }
         self.status_effects: Dict[int, List[Dict[str, Any]]] = {}
@@ -156,6 +158,7 @@ class GameSession:
         self.atb_gauges = {}
         self.enemy_atb = 0.0
         self.atb_task = None
+        self.speed_bonus_used = False
 
     def update_ability_cooldown(self, player_id: int, ability_id: int, cd: float) -> None:
         """Set the cooldown timer for a player's ability."""
@@ -205,6 +208,7 @@ class GameSession:
             "atb_gauges": self.atb_gauges,
             "enemy_atb": self.enemy_atb,
             "atb_task": None,
+            "speed_bonus_used": self.speed_bonus_used,
             "trance_states": self.trance_states,
             "status_effects": self.status_effects,
             "current_enemy": self.current_enemy
@@ -234,6 +238,7 @@ class GameSession:
         gs.atb_gauges        = data.get("atb_gauges", {})
         gs.enemy_atb         = data.get("enemy_atb", 0.0)
         gs.atb_task          = None
+        gs.speed_bonus_used  = data.get("speed_bonus_used", False)
         gs.trance_states     = data.get("trance_states", {})
         gs.status_effects    = data.get("status_effects", {})
         gs.current_enemy     = data.get("current_enemy")

--- a/tests/test_speed_advantage.py
+++ b/tests/test_speed_advantage.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import types
+
+# Stub mysql & discord modules similar to other tests
+sys.modules.setdefault("mysql", types.ModuleType("mysql"))
+sys.modules.setdefault("mysql.connector", types.ModuleType("connector"))
+sys.modules.setdefault("aiomysql", types.ModuleType("aiomysql"))
+sys.modules["mysql"].connector = sys.modules["mysql.connector"]
+sys.modules["mysql.connector"].connection = types.SimpleNamespace(MySQLConnection=object)
+
+sys.modules.setdefault("discord", types.ModuleType("discord"))
+sys.modules.setdefault("discord.ext", types.ModuleType("ext"))
+ext_mod = sys.modules["discord.ext"]
+ext_mod.commands = types.ModuleType("commands")
+sys.modules["discord.ext.commands"] = ext_mod.commands
+ext_mod.commands.Cog = type("Cog", (), {})
+ext_mod.commands.Bot = object
+ext_mod.commands.command = lambda *a, **k: (lambda f: f)
+ext_mod.commands.Cog.listener = lambda *a, **k: (lambda f: f)
+ext_mod.commands.has_guild_permissions = lambda **k: (lambda f: f)
+ext_mod.commands.has_permissions = lambda **k: (lambda f: f)
+ext_mod.commands.Context = object
+discord = sys.modules["discord"]
+discord.InteractionType = types.SimpleNamespace(component=1)
+discord.ui = types.SimpleNamespace(View=object, Button=object)
+discord.ui.button = lambda *a, **k: (lambda f: f)
+discord.ButtonStyle = types.SimpleNamespace(primary=1, secondary=2, success=3, danger=4, blurple=5)
+discord.Color = types.SimpleNamespace(gold=lambda: None)
+discord.Interaction = type("Interaction", (), {})
+discord.Embed = type("Embed", (), {"__init__": lambda self, **k: None})
+discord.abc = types.SimpleNamespace(Messageable=object)
+discord.Message = type("Message", (), {})
+discord.Thread = type("Thread", (), {})
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from game.battle_system import BattleSystem
+
+class FakeSession:
+    def __init__(self):
+        self.battle_state = {"player_effects": [], "enemy_effects": []}
+        self.speed_bonus_used = False
+
+bs = BattleSystem(types.SimpleNamespace(get_cog=lambda name: None))
+
+
+def test_speed_advantage_requires_status():
+    session = FakeSession()
+    player = {"speed": 20}
+    enemy = {"speed": 5}
+    assert bs._check_speed_advantage(session, player, enemy) is None
+
+    session.battle_state["player_effects"].append({"speed_up": 5, "effect_name": "Haste", "remaining": 2})
+    session.speed_bonus_used = False
+    assert bs._check_speed_advantage(session, player, enemy) == "player"
+    assert session.speed_bonus_used is True
+    # second call should not grant another turn
+    assert bs._check_speed_advantage(session, player, enemy) is None
+
+    session.speed_bonus_used = False
+    session.battle_state["player_effects"] = []
+    session.battle_state["enemy_effects"].append({"speed_down": 5, "effect_name": "Slow", "remaining": 2})
+    assert bs._check_speed_advantage(session, player, enemy) == "player"


### PR DESCRIPTION
## Summary
- track single speed-bonus turn in `GameSession`
- show ATB progress on every tick and notify once when full
- refresh battle view each tick with `BattleSystem.on_tick`
- reset gauges after actions
- require Haste/Slow for speed-based extra turns
- test new speed advantage logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856a9f3111c8328b740a1eb88a1b45d