### PR TITLE
Add Unity battle framework

### DIFF
--- a/Evolution/Assets/Scripts/Combat/ATBManager.cs
+++ b/Evolution/Assets/Scripts/Combat/ATBManager.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Evolution.Combat
+{
+    public class ATBManager : MonoBehaviour
+    {
+        [SerializeField] private float tickSeconds = 0.5f;
+        [SerializeField] private float updateInterval = 1f;
+
+        private Coroutine tickRoutine;
+        private BattleManager battle;
+        private BattleState state;
+
+        public event Action OnTick;
+        public event Action<int> OnPlayerReady;
+        public event Action OnEnemyReady;
+
+        public void StartATB(BattleManager manager, BattleState battleState)
+        {
+            StopATB();
+            battle = manager;
+            state = battleState;
+            tickRoutine = StartCoroutine(TickLoop());
+        }
+
+        public void StopATB()
+        {
+            if (tickRoutine != null)
+            {
+                StopCoroutine(tickRoutine);
+                tickRoutine = null;
+            }
+        }
+
+        private IEnumerator TickLoop()
+        {
+            float lastUpdate = Time.time;
+            var notifiedPlayers = new Dictionary<int, bool>();
+            var lastInts = new Dictionary<int, int>();
+            int lastEnemy = 0;
+            foreach (var kvp in state.PlayerSpeeds)
+            {
+                notifiedPlayers[kvp.Key] = false;
+                lastInts[kvp.Key] = 0;
+            }
+            bool enemyNotified = false;
+
+            while (state.InBattle)
+            {
+                yield return new WaitForSeconds(tickSeconds);
+                if (state.Paused)
+                    continue;
+
+                float delta = tickSeconds;
+                foreach (var kvp in state.PlayerSpeeds)
+                {
+                    int id = kvp.Key;
+                    float maxVal = state.PlayerMaxATB[id];
+                    if (state.PlayerATB[id] < maxVal)
+                    {
+                        float effective = kvp.Value + state.GetSpeedBonus(id);
+                        state.PlayerATB[id] += effective * delta;
+                        if (state.PlayerATB[id] >= maxVal)
+                            state.PlayerATB[id] = maxVal;
+                    }
+
+                    if (state.PlayerATB[id] >= maxVal)
+                    {
+                        if (!notifiedPlayers[id])
+                        {
+                            notifiedPlayers[id] = true;
+                            OnPlayerReady?.Invoke(id);
+                        }
+                    }
+                    else
+                    {
+                        notifiedPlayers[id] = false;
+                    }
+                }
+
+                if (state.EnemyATB < state.EnemyMaxATB)
+                {
+                    float eff = state.EnemySpeed + state.GetEnemySpeedBonus();
+                    state.EnemyATB += eff * delta;
+                    if (state.EnemyATB >= state.EnemyMaxATB)
+                        state.EnemyATB = state.EnemyMaxATB;
+                }
+
+                if (state.EnemyATB >= state.EnemyMaxATB)
+                {
+                    if (!enemyNotified)
+                    {
+                        enemyNotified = true;
+                        OnEnemyReady?.Invoke();
+                    }
+                }
+                else
+                {
+                    enemyNotified = false;
+                }
+
+                bool trigger = false;
+                foreach (var id in state.PlayerSpeeds.Keys)
+                {
+                    int cur = (int)state.PlayerATB[id];
+                    if (cur != lastInts[id])
+                    {
+                        lastInts[id] = cur;
+                        trigger = true;
+                    }
+                }
+                int eCur = (int)state.EnemyATB;
+                if (eCur != lastEnemy)
+                {
+                    lastEnemy = eCur;
+                    trigger = true;
+                }
+
+                if (trigger || Time.time - lastUpdate >= updateInterval)
+                {
+                    OnTick?.Invoke();
+                    lastUpdate = Time.time;
+                }
+            }
+            tickRoutine = null;
+        }
+    }
+}

--- a/Evolution/Assets/Scripts/Combat/BattleManager.cs
+++ b/Evolution/Assets/Scripts/Combat/BattleManager.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Evolution.Combat
+{
+    [Serializable]
+    public class StatusEffect
+    {
+        public string EffectName;
+        public int Remaining;
+        public int DamagePerTurn;
+        public int HealPerTurn;
+        public float SpeedUp;
+        public float SpeedDown;
+    }
+
+    [Serializable]
+    public class Ability
+    {
+        public string Name;
+        public int Damage;
+        public int Heal;
+        public StatusEffect Effect;
+        public float Cooldown;
+        public bool TargetSelf;
+    }
+
+    [Serializable]
+    public class Combatant
+    {
+        public int Id;
+        public int Hp;
+        public int MaxHp;
+        public float Speed;
+        public float ATB;
+        public float ATBMax = 5f;
+        public Dictionary<string, float> Cooldowns = new();
+        public List<StatusEffect> Effects = new();
+
+        public float GetSpeedBonus()
+        {
+            float bonus = 0f;
+            foreach (var se in Effects)
+                bonus += se.SpeedUp - se.SpeedDown;
+            return bonus;
+        }
+
+        public void TickStatus()
+        {
+            List<StatusEffect> next = new();
+            foreach (var se in Effects)
+            {
+                if (se.DamagePerTurn > 0)
+                    Hp = Mathf.Max(Hp - se.DamagePerTurn, 0);
+                if (se.HealPerTurn > 0)
+                    Hp = Mathf.Min(Hp + se.HealPerTurn, MaxHp);
+                se.Remaining--;
+                if (se.Remaining > 0)
+                    next.Add(se);
+            }
+            Effects = next;
+        }
+    }
+
+    [Serializable]
+    public class BattleState
+    {
+        public Dictionary<int, Combatant> Players = new();
+        public Combatant Enemy = new();
+        public bool Paused;
+        public bool InBattle;
+
+        public Dictionary<int, float> PlayerSpeeds
+        {
+            get
+            {
+                var d = new Dictionary<int, float>();
+                foreach (var kv in Players)
+                    d[kv.Key] = kv.Value.Speed;
+                return d;
+            }
+        }
+        public Dictionary<int, float> PlayerATB
+        {
+            get
+            {
+                var d = new Dictionary<int, float>();
+                foreach (var kv in Players)
+                    d[kv.Key] = kv.Value.ATB;
+                return d;
+            }
+            set
+            {
+                foreach (var kv in value)
+                    if (Players.ContainsKey(kv.Key))
+                        Players[kv.Key].ATB = kv.Value;
+            }
+        }
+        public Dictionary<int, float> PlayerMaxATB
+        {
+            get
+            {
+                var d = new Dictionary<int, float>();
+                foreach (var kv in Players)
+                    d[kv.Key] = kv.Value.ATBMax;
+                return d;
+            }
+        }
+        public float EnemyATB { get { return Enemy.ATB; } set { Enemy.ATB = value; } }
+        public float EnemyMaxATB { get { return Enemy.ATBMax; } set { Enemy.ATBMax = value; } }
+        public float EnemySpeed { get { return Enemy.Speed; } set { Enemy.Speed = value; } }
+
+        public float GetSpeedBonus(int playerId)
+        {
+            if (!Players.ContainsKey(playerId)) return 0f;
+            return Players[playerId].GetSpeedBonus();
+        }
+        public float GetEnemySpeedBonus() => Enemy.GetSpeedBonus();
+    }
+
+    public class BattleManager : MonoBehaviour
+    {
+        public ATBManager AtbManager;
+        public BattleState State = new();
+
+        public event Action OnUIUpdate;
+
+        private void Awake()
+        {
+            if (AtbManager == null)
+                AtbManager = GetComponent<ATBManager>();
+            if (AtbManager != null)
+            {
+                AtbManager.OnPlayerReady += HandlePlayerReady;
+                AtbManager.OnEnemyReady += HandleEnemyReady;
+                AtbManager.OnTick += () => OnUIUpdate?.Invoke();
+            }
+        }
+
+        public void StartBattle(Combatant enemy, IEnumerable<Combatant> players)
+        {
+            State = new BattleState { InBattle = true, Enemy = enemy };
+            foreach (var p in players)
+                State.Players[p.Id] = p;
+            if (AtbManager != null)
+                AtbManager.StartATB(this, State);
+        }
+
+        public void EndBattle()
+        {
+            State.InBattle = false;
+            if (AtbManager != null)
+                AtbManager.StopATB();
+        }
+
+        private void HandlePlayerReady(int id)
+        {
+            StartCoroutine(PlayerTurn(id));
+        }
+
+        private void HandleEnemyReady()
+        {
+            StartCoroutine(EnemyTurn());
+        }
+
+        private IEnumerator PlayerTurn(int playerId)
+        {
+            State.Paused = true;
+            var player = State.Players[playerId];
+            player.TickStatus();
+            OnUIUpdate?.Invoke();
+            // waiting for external input in real game
+            yield return null;
+        }
+
+        private IEnumerator EnemyTurn()
+        {
+            State.Paused = true;
+            State.Enemy.TickStatus();
+            ApplyEnemyAI();
+            OnUIUpdate?.Invoke();
+            yield return new WaitForSeconds(1f);
+            State.Enemy.ATB = 0f;
+            State.Paused = false;
+        }
+
+        private void ApplyEnemyAI()
+        {
+            var ability = ChooseEnemyAbility();
+            if (ability == null)
+                return;
+            ApplyAbility(State.Enemy, State.Players[State.Players.Keys.First()], ability); // simple: target first player
+        }
+
+        private Ability ChooseEnemyAbility()
+        {
+            // stub random ability; extend as needed
+            return null;
+        }
+
+        public void ApplyAbility(Combatant user, Combatant target, Ability ability)
+        {
+            if (ability == null) return;
+            if (ability.Damage > 0)
+            {
+                target.Hp = Mathf.Max(target.Hp - ability.Damage, 0);
+            }
+            if (ability.Heal > 0)
+            {
+                if (ability.TargetSelf)
+                    user.Hp = Mathf.Min(user.Hp + ability.Heal, user.MaxHp);
+                else
+                    target.Hp = Mathf.Min(target.Hp + ability.Heal, target.MaxHp);
+            }
+            if (ability.Effect != null && ability.Effect.Remaining > 0)
+            {
+                var effTarget = ability.TargetSelf ? user : target;
+                effTarget.Effects.Add(ability.Effect);
+            }
+            if (OnUIUpdate != null)
+                OnUIUpdate.Invoke();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement ATBManager.cs to handle Active Time Battle gauge logic
- add BattleManager.cs with simple ability resolution and status effects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68574ab841c48328b5c6da1fedbb5566