### PR TITLE
Add Unity gameplay managers

### DIFF
--- a/Evolution/Assets/Scripts/Core/DatabaseClient.cs
+++ b/Evolution/Assets/Scripts/Core/DatabaseClient.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Data;
+using MySql.Data.MySqlClient;
+using UnityEngine;
+
+namespace Evolution.Core
+{
+    /// <summary>
+    /// Lightweight MySQL client used by the Unity front end.
+    /// Wraps connection handling so other classes can persist session data.
+    /// </summary>
+    public class DatabaseClient
+    {
+        private readonly string connectionString;
+
+        public DatabaseClient(string host, string user, string password, string database)
+        {
+            connectionString = $"Server={host};User ID={user};Password={password};Database={database};Pooling=true";
+        }
+
+        private MySqlConnection CreateConnection()
+        {
+            var conn = new MySqlConnection(connectionString);
+            conn.Open();
+            return conn;
+        }
+
+        public void Execute(string query, Action<IDbCommand> paramHandler)
+        {
+            using var conn = CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = query;
+            paramHandler?.Invoke(cmd);
+            cmd.ExecuteNonQuery();
+        }
+
+        public T QueryScalar<T>(string query, Action<IDbCommand> paramHandler)
+        {
+            using var conn = CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = query;
+            paramHandler?.Invoke(cmd);
+            object result = cmd.ExecuteScalar();
+            if (result == null || result == DBNull.Value) return default;
+            return (T)Convert.ChangeType(result, typeof(T));
+        }
+
+        public IDataReader Query(string query, Action<IDbCommand> paramHandler)
+        {
+            var conn = CreateConnection();
+            var cmd = conn.CreateCommand();
+            cmd.CommandText = query;
+            paramHandler?.Invoke(cmd);
+            // caller must dispose reader and connection
+            return cmd.ExecuteReader(CommandBehavior.CloseConnection);
+        }
+    }
+}

--- a/Evolution/Assets/Scripts/Core/GameManager.cs
+++ b/Evolution/Assets/Scripts/Core/GameManager.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Evolution.Dungeon;
+using Evolution.Combat;
+
+namespace Evolution.Core
+{
+    /// <summary>
+    /// Top level orchestrator for dungeon exploration. Inspired by the
+    /// Python GameMaster class, this version drives gameplay inside Unity
+    /// and communicates with the backend through <see cref="DatabaseClient"/>.
+    /// </summary>
+    public class GameManager : MonoBehaviour
+    {
+        [SerializeField] private DungeonGenerator generator;
+        [SerializeField] private BattleManager battleManager;
+        [SerializeField] private SessionManager sessionManager;
+        [SerializeField] private string difficulty = "Easy";
+
+        public event Action<RoomData> OnRoomEntered;
+        public event Action<DungeonData> OnDungeonLoaded;
+
+        private SessionData currentSession;
+
+        public void StartNewGame(int ownerId)
+        {
+            if (sessionManager == null || generator == null)
+            {
+                Debug.LogError("GameManager missing dependencies");
+                return;
+            }
+            currentSession = new SessionData
+            {
+                SessionId = ownerId, // temporary id if no DB yet
+                OwnerId = ownerId,
+                Difficulty = difficulty,
+                CurrentFloor = 1,
+                CurrentPosition = Vector2Int.zero,
+                Dungeon = generator.GenerateDungeon()
+            };
+            sessionManager.RegisterSession(currentSession);
+            OnDungeonLoaded?.Invoke(currentSession.Dungeon);
+            EnterRoom(currentSession.CurrentPosition);
+        }
+
+        public void LoadSession(int sessionId)
+        {
+            if (sessionManager == null) return;
+            currentSession = sessionManager.LoadSession(sessionId);
+            if (currentSession != null)
+            {
+                OnDungeonLoaded?.Invoke(currentSession.Dungeon);
+                EnterRoom(currentSession.CurrentPosition);
+            }
+            else
+            {
+                Debug.LogWarning($"Session {sessionId} not found");
+            }
+        }
+
+        public void Move(Vector2Int delta)
+        {
+            if (currentSession == null) return;
+            Vector2Int next = currentSession.CurrentPosition + delta;
+            var floor = currentSession.Dungeon.Floors[currentSession.CurrentFloor - 1];
+            foreach (var room in floor.Rooms)
+            {
+                if (room.Coord == next)
+                {
+                    currentSession.CurrentPosition = next;
+                    EnterRoom(next);
+                    sessionManager.SaveSession(currentSession);
+                    return;
+                }
+            }
+            Debug.Log("Cannot move in that direction");
+        }
+
+        private void EnterRoom(Vector2Int coord)
+        {
+            var floor = currentSession.Dungeon.Floors[currentSession.CurrentFloor - 1];
+            RoomData room = floor.Rooms.Find(r => r.Coord == coord);
+            if (room == null) return;
+            HandleRoom(room);
+            OnRoomEntered?.Invoke(room);
+        }
+
+        private void HandleRoom(RoomData room)
+        {
+            switch (room.Type)
+            {
+                case RoomType.Monster:
+                case RoomType.Boss:
+                    if (battleManager != null)
+                    {
+                        var enemy = new Combatant { Id = 0, Hp = 10, MaxHp = 10, Speed = 1f };
+                        var player = new Combatant { Id = currentSession.OwnerId, Hp = 10, MaxHp = 10, Speed = 1f };
+                        battleManager.StartBattle(enemy, new List<Combatant> { player });
+                    }
+                    break;
+                case RoomType.Locked:
+                    Debug.Log("Encountered a locked door.");
+                    break;
+                case RoomType.Treasure:
+                    Debug.Log("Found a treasure chest!");
+                    break;
+                case RoomType.StaircaseDown:
+                    currentSession.CurrentFloor++;
+                    currentSession.CurrentPosition = Vector2Int.zero;
+                    OnDungeonLoaded?.Invoke(currentSession.Dungeon);
+                    break;
+                case RoomType.StaircaseUp:
+                    currentSession.CurrentFloor = Math.Max(1, currentSession.CurrentFloor - 1);
+                    currentSession.CurrentPosition = Vector2Int.zero;
+                    OnDungeonLoaded?.Invoke(currentSession.Dungeon);
+                    break;
+            }
+        }
+    }
+}

--- a/Evolution/Assets/Scripts/Core/SessionManager.cs
+++ b/Evolution/Assets/Scripts/Core/SessionManager.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Evolution.Core
+{
+    /// <summary>
+    /// Tracks active game sessions and provides basic persistence through
+    /// <see cref="DatabaseClient"/>. This mirrors the Python SessionManager
+    /// used by the Discord bot but is tailored for a local Unity game.
+    /// </summary>
+    public class SessionManager : MonoBehaviour
+    {
+        private readonly Dictionary<int, SessionData> sessions = new();
+        private DatabaseClient db;
+
+        public void Initialise(DatabaseClient client)
+        {
+            db = client;
+        }
+
+        public SessionData GetSession(int id)
+        {
+            sessions.TryGetValue(id, out var sess);
+            return sess;
+        }
+
+        public void RegisterSession(SessionData data)
+        {
+            if (data == null) return;
+            sessions[data.SessionId] = data;
+        }
+
+        public void SaveSession(SessionData data)
+        {
+            if (db == null || data == null) return;
+            sessions[data.SessionId] = data;
+            string json = JsonUtility.ToJson(data);
+            db.Execute(
+                "UPDATE sessions SET game_state=@state WHERE session_id=@id",
+                cmd =>
+                {
+                    var pState = cmd.CreateParameter();
+                    pState.ParameterName = "@state";
+                    pState.Value = json;
+                    cmd.Parameters.Add(pState);
+
+                    var pId = cmd.CreateParameter();
+                    pId.ParameterName = "@id";
+                    pId.Value = data.SessionId;
+                    cmd.Parameters.Add(pId);
+                });
+        }
+
+        public SessionData LoadSession(int sessionId)
+        {
+            if (db == null) return null;
+            string json = db.QueryScalar<string>(
+                "SELECT game_state FROM sessions WHERE session_id=@id",
+                cmd =>
+                {
+                    var p = cmd.CreateParameter();
+                    p.ParameterName = "@id";
+                    p.Value = sessionId;
+                    cmd.Parameters.Add(p);
+                });
+            if (string.IsNullOrEmpty(json)) return null;
+            var data = JsonUtility.FromJson<SessionData>(json);
+            sessions[sessionId] = data;
+            return data;
+        }
+    }
+
+    [System.Serializable]
+    public class SessionData
+    {
+        public int SessionId;
+        public int OwnerId;
+        public string Difficulty;
+        public int CurrentFloor;
+        public Vector2Int CurrentPosition;
+        public Dungeon.DungeonData Dungeon;
+        public List<int> Players = new();
+    }
+}


### PR DESCRIPTION
## Summary
- add DatabaseClient helper for MySQL connections
- implement GameManager orchestrating dungeon flow
- implement SessionManager for saving/loading sessions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685750c31fe483288a93ea3f10eea99b