### PR TITLE
Add Unity UI management scripts

### DIFF
--- a/Evolution/Assets/Scripts/Editor/UIManagerEditor.cs
+++ b/Evolution/Assets/Scripts/Editor/UIManagerEditor.cs
@@ -1,0 +1,29 @@
+using UnityEditor;
+using Evolution.UI;
+
+namespace Evolution.Editor
+{
+    [CustomEditor(typeof(UIManager))]
+    public class UIManagerEditor : UnityEditor.Editor
+    {
+        private SerializedProperty themeColor;
+        private SerializedProperty themeFont;
+
+        private void OnEnable()
+        {
+            themeColor = serializedObject.FindProperty("themeColor");
+            themeFont = serializedObject.FindProperty("themeFont");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+            EditorGUILayout.PropertyField(themeColor);
+            EditorGUILayout.PropertyField(themeFont);
+            EditorGUILayout.Space();
+            DrawPropertiesExcluding(serializedObject, "m_Script", "themeColor", "themeFont");
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}
+

--- a/Evolution/Assets/Scripts/UI/BattleUI.cs
+++ b/Evolution/Assets/Scripts/UI/BattleUI.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using Evolution.Combat;
+
+namespace Evolution.UI
+{
+    /// <summary>
+    /// Displays ATB gauges for players and enemies during battle.
+    /// </summary>
+    public class BattleUI : MonoBehaviour
+    {
+        [SerializeField] private BattleManager battleManager;
+        [SerializeField] private Slider enemyGauge;
+        [SerializeField] private Slider playerGaugePrefab;
+        [SerializeField] private Transform playerGaugeRoot;
+
+        private readonly Dictionary<int, Slider> playerGauges = new();
+
+        private void OnEnable()
+        {
+            if (battleManager != null)
+                battleManager.OnUIUpdate += Refresh;
+        }
+
+        private void OnDisable()
+        {
+            if (battleManager != null)
+                battleManager.OnUIUpdate -= Refresh;
+        }
+
+        public void SetBattleManager(BattleManager manager)
+        {
+            if (battleManager != null)
+                battleManager.OnUIUpdate -= Refresh;
+            battleManager = manager;
+            if (battleManager != null)
+                battleManager.OnUIUpdate += Refresh;
+            Refresh();
+        }
+
+        private void Refresh()
+        {
+            if (battleManager == null || !battleManager.State.InBattle)
+                return;
+
+            var state = battleManager.State;
+            if (enemyGauge != null)
+            {
+                enemyGauge.maxValue = state.EnemyMaxATB;
+                enemyGauge.value = state.EnemyATB;
+            }
+
+            foreach (var kv in state.Players)
+            {
+                if (!playerGauges.TryGetValue(kv.Key, out Slider s))
+                {
+                    if (playerGaugePrefab != null && playerGaugeRoot != null)
+                    {
+                        s = Instantiate(playerGaugePrefab, playerGaugeRoot);
+                        playerGauges[kv.Key] = s;
+                    }
+                }
+                if (s != null)
+                {
+                    s.maxValue = kv.Value.ATBMax;
+                    s.value = kv.Value.ATB;
+                }
+            }
+        }
+    }
+}
+

--- a/Evolution/Assets/Scripts/UI/MapUI.cs
+++ b/Evolution/Assets/Scripts/UI/MapUI.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using Evolution.Dungeon;
+
+namespace Evolution.UI
+{
+    /// <summary>
+    /// Basic visualization of a dungeon floor. Generates simple icons for each
+    /// room and highlights the player's current location.
+    /// </summary>
+    public class MapUI : MonoBehaviour
+    {
+        [SerializeField] private RectTransform mapRoot;
+        [SerializeField] private GameObject roomPrefab;
+        [SerializeField] private Color exploredColor = Color.gray;
+        [SerializeField] private Color currentColor = Color.yellow;
+
+        private readonly List<GameObject> spawned = new();
+
+        public void DrawFloor(FloorData floor, Vector2Int current)
+        {
+            Clear();
+            if (floor == null || mapRoot == null || roomPrefab == null)
+                return;
+            foreach (var room in floor.Rooms)
+            {
+                var go = Instantiate(roomPrefab, mapRoot);
+                var image = go.GetComponent<Image>();
+                if (image != null)
+                    image.color = room.Coord == current ? currentColor : exploredColor;
+                go.transform.localPosition = new Vector3(room.Coord.x * 32f, room.Coord.y * 32f, 0f);
+                spawned.Add(go);
+            }
+        }
+
+        public void Clear()
+        {
+            foreach (var go in spawned)
+                if (go != null)
+                    Destroy(go);
+            spawned.Clear();
+        }
+    }
+}
+

--- a/Evolution/Assets/Scripts/UI/UIManager.cs
+++ b/Evolution/Assets/Scripts/UI/UIManager.cs
@@ -1,0 +1,124 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using Evolution.Dungeon;
+
+namespace Evolution.UI
+{
+    /// <summary>
+    /// Controls high level user interface canvases such as room descriptions,
+    /// battle logs and the main menu. Visual elements can be themed via the
+    /// inspector.
+    /// </summary>
+    public class UIManager : MonoBehaviour
+    {
+        [Header("Canvas Groups")]
+        [SerializeField] private CanvasGroup roomCanvas;
+        [SerializeField] private CanvasGroup battleCanvas;
+        [SerializeField] private CanvasGroup menuCanvas;
+
+        [Header("Room Elements")]
+        [SerializeField] private Text roomDescription;
+
+        [Header("Battle Elements")]
+        [SerializeField] private Text battleLog;
+
+        [Header("Theme")]
+        [SerializeField] private Color themeColor = Color.white;
+        [SerializeField] private Font themeFont;
+
+        public Color ThemeColor { get => themeColor; set { themeColor = value; ApplyTheme(); } }
+        public Font ThemeFont { get => themeFont; set { themeFont = value; ApplyTheme(); } }
+
+        private void Awake()
+        {
+            ApplyTheme();
+        }
+
+        private void ApplyTheme()
+        {
+            if (roomDescription != null)
+            {
+                roomDescription.color = themeColor;
+                if (themeFont != null) roomDescription.font = themeFont;
+            }
+            if (battleLog != null)
+            {
+                battleLog.color = themeColor;
+                if (themeFont != null) battleLog.font = themeFont;
+            }
+        }
+
+        public void ShowRoom(RoomData room)
+        {
+            if (roomCanvas != null)
+            {
+                roomCanvas.alpha = 1f;
+                roomCanvas.interactable = true;
+                roomCanvas.blocksRaycasts = true;
+            }
+            if (battleCanvas != null)
+            {
+                battleCanvas.alpha = 0f;
+                battleCanvas.interactable = false;
+                battleCanvas.blocksRaycasts = false;
+            }
+            if (menuCanvas != null)
+            {
+                menuCanvas.alpha = 0f;
+                menuCanvas.interactable = false;
+                menuCanvas.blocksRaycasts = false;
+            }
+            if (roomDescription != null && room != null)
+                roomDescription.text = $"{room.Type}: {room.Coord}";
+        }
+
+        public void ShowBattle(string log)
+        {
+            if (battleCanvas != null)
+            {
+                battleCanvas.alpha = 1f;
+                battleCanvas.interactable = true;
+                battleCanvas.blocksRaycasts = true;
+            }
+            if (roomCanvas != null)
+            {
+                roomCanvas.alpha = 0f;
+                roomCanvas.interactable = false;
+                roomCanvas.blocksRaycasts = false;
+            }
+            if (battleLog != null)
+                battleLog.text = log;
+        }
+
+        public void ShowMenu()
+        {
+            if (menuCanvas != null)
+            {
+                menuCanvas.alpha = 1f;
+                menuCanvas.interactable = true;
+                menuCanvas.blocksRaycasts = true;
+            }
+        }
+
+        // ──────────────────────────────────────────────────────────────
+        // Placeholder methods for illusion rooms based on embed_manager.py
+        // lines 568‑576. These will be implemented in a future iteration.
+        // ──────────────────────────────────────────────────────────────
+        public void ShowIllusionRoom()
+        {
+            // TODO: display generic illusion challenge UI
+        }
+
+        public void ShowIllusionCrystal(int index, IList<object> crystals)
+        {
+            // TODO: present elemental crystal at given index
+        }
+
+        public void ShowIllusionEnemyCount(IList<int> options)
+        {
+            // TODO: ask player for enemy count guess
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `UIManager` to handle room descriptions, battle logs and menus
- create `MapUI` to render dungeon floors
- add `BattleUI` for ATB gauge display
- provide a custom inspector for theme colors and fonts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685755abdd9c83289336a1cafe76e82f