### PR TITLE
Keep entrance tile distinct on mini-map

### DIFF
--- a/game/dungeon_generator.py
+++ b/game/dungeon_generator.py
@@ -175,7 +175,7 @@ class DungeonGenerator(commands.Cog):
                     """
                     SELECT template_id
                       FROM room_templates
-                     WHERE room_type NOT IN ('locked','safe','chest_unlocked','boss','exit','illusion')
+                     WHERE room_type NOT IN ('locked','safe','chest_unlocked','boss','exit','illusion','entrance')
                      ORDER BY RAND()
                      LIMIT 1
                     """
@@ -514,7 +514,7 @@ class DungeonGenerator(commands.Cog):
                 elif coord == exit_coord:
                     rtype = "exit"
                 elif coord == (start_x, start_y):
-                    rtype = "safe" if floor_number == 1 else "staircase_down"
+                    rtype = "entrance" if floor_number == 1 else "staircase_down"
                 elif coord in shop_positions:
                     rtype = "shop"
                 else:

--- a/game/embed_manager.py
+++ b/game/embed_manager.py
@@ -348,7 +348,7 @@ class EmbedManager(commands.Cog):
         embed.add_field(
             name="__**Legend**__",
             value=(
-                "**🤺 You**  **🟨 Visited**  **🟩 Safe**  **🟥 Monster**  **⬛ Unknown**\n"
+                "**🤺 You**  **🟨 Visited**  **⬜ Entrance**  **🟩 Safe**  **🟥 Monster**  **⬛ Unknown**\n"
                 "**🟦 Item**  **👤 Quest**  **🔼 Up**  **🔽 Down**\n"
                 "**🟧 Trap**  **🔒 Locked**  **🟪 Shop**  **🔮 Illusion**\n"
                 "**💀 Boss**  **🚪 Exit**  **⚰️ Fallen Player**"

--- a/utils/ui_helpers.py
+++ b/utils/ui_helpers.py
@@ -59,6 +59,7 @@ def get_emoji_for_room_type(room_type: str) -> str:
     """
     mapping = {
         "safe":           "🟩",
+        "entrance":       "⬜",
         "monster":        "🟥",
         "boss":           "💀",
         "illusion":       "🔮",


### PR DESCRIPTION
## Summary
- keep entrance rooms rendering with their own icon instead of being marked as visited
- switch entrance icon to a white square on the mini-map legend and emoji mapping

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943f3dcf5f88328a1ed36f5c074d2c9)