### PR TITLE
Add session `saved` flag, extend room types, and restore chest lookup

### DIFF
--- a/game/game_master.py
+++ b/game/game_master.py
@@ -817,11 +817,10 @@ class GameMaster(commands.Cog):
                     cur.execute("""
                         SELECT tci.instance_id, tci.is_unlocked
                         FROM treasure_chest_instances tci
-                        JOIN rooms r ON r.room_id = tci.room_id
                         WHERE tci.session_id = %s
-                        AND r.floor_id = %s
-                        AND r.coord_x = %s
-                        AND r.coord_y = %s
+                        AND tci.floor_id = %s
+                        AND tci.coord_x = %s
+                        AND tci.coord_y = %s
                         LIMIT 1
                     """, (
                         session.session_id,


### PR DESCRIPTION
### Motivation
- Sessions lacked a persistent `saved` flag used by cleanup and load routines; existing code expects this column.
- New room types (`miniboss`, `death`) were added elsewhere but not present in the DB enums, leading to schema/logic mismatches.
- The unlock‑chest button stopped appearing in item rooms because chest instance lookup relied on a join to `rooms` instead of using the stored coordinates on `treasure_chest_instances`.
- These mismatches broke flow for saved games, battle triggers, and chest unlock UI, so schema + query fixes are required.

### Description
- Added a `saved` boolean column to the `sessions` table DDL (`database/database_setup.py`) and backfilled existing rows in `ensure_schema_columns` via `add_column_if_missing` and `UPDATE`.
- Expanded the `room_type` enum to include `miniboss` and `death` in the `room_templates` and `rooms` table definitions and enforced it at runtime by applying an `ALTER TABLE ... MODIFY COLUMN room_type ENUM(...)` in `ensure_schema_columns`.
- Restored chest unlock detection by changing the chest lookup in `game/game_master.py` to query `treasure_chest_instances` by its `floor_id`, `coord_x`, and `coord_y` (instead of joining to `rooms`). This allows the unlock button to be shown for item rooms with locked chest instances.
- Files modified: `database/database_setup.py`, `game/game_master.py`.

### Testing
- No automated tests were run as part of this change.
- Changes were limited to schema DDL and a single query; please run your normal integration/migration tests and apply the DB migration before deploying to production.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944b0404ccc83288f36725fb332341d)