### PR TITLE
Add `session_saves` table to database setup

### DIFF
--- a/database/database_setup.py
+++ b/database/database_setup.py
@@ -1128,6 +1128,19 @@ TABLES = {
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
     ''',
+    # ---------- session_saves ----------
+    'session_saves': '''
+        CREATE TABLE IF NOT EXISTS session_saves (
+            session_id INT NOT NULL,
+            slot INT NOT NULL,
+            save_title VARCHAR(100) NOT NULL,
+            is_auto_save BOOLEAN NOT NULL DEFAULT FALSE,
+            saved_state JSON NOT NULL,
+            timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (session_id, slot),
+            FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+        )
+    ''',
     # ---------- intro_steps ----------
     'intro_steps': '''
         CREATE TABLE IF NOT EXISTS intro_steps (
@@ -1277,6 +1290,7 @@ TABLE_ORDER = [
     'enemy_resistances',
     'game_events',
     'game_saves',
+    'session_saves',
     'intro_steps',
     'ability_status_effects',
     'item_effects',


### PR DESCRIPTION
### Motivation
- The save/load/list commands in `game/save_game.py` use a `session_saves` table, but the schema only defined `game_saves`, causing runtime errors when saving/loading sessions.
- Align the database schema with backend expectations so session-level saves work correctly.

### Description
- Add a new `session_saves` table definition to `database/database_setup.py` with columns: `session_id`, `slot`, `save_title`, `is_auto_save`, `saved_state`, and `timestamp`.
- Use a composite primary key on `(session_id, slot)` and a foreign key `session_id` -> `sessions(session_id)` with `ON DELETE CASCADE`.
- Insert the new `session_saves` entry into the `TABLES` map and include `'session_saves'` in `TABLE_ORDER` so it is created in the correct sequence.
- Leave existing `game_saves` definition unchanged.

### Testing
- No automated tests were run for this schema-only change.
- Manual code inspection and search (`rg`) were used to confirm that `game/save_game.py` references `session_saves` and that the new table now appears in the setup script.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944bd8c08508328826debab846adb32)