### PR TITLE
Select difficulty before creating queue/LFG; include difficulty in hub post

### DIFF
--- a/game/embed_manager.py
+++ b/game/embed_manager.py
@@ -271,7 +271,12 @@ class EmbedManager(commands.Cog):
     # ──────────────────────────────────────────────────────────────────
     # Difficulty selection embed
     # ──────────────────────────────────────────────────────────────────
-    async def send_difficulty_selection(self, interaction: discord.Interaction):
+    async def send_difficulty_selection(
+        self,
+        interaction: discord.Interaction,
+        *,
+        channel: Optional[discord.abc.Messageable] = None,
+    ):
         conn = self.db_connect()
         with conn.cursor(dictionary=True) as cur:
             cur.execute("SELECT name FROM difficulties ORDER BY difficulty_id ASC")
@@ -280,7 +285,13 @@ class EmbedManager(commands.Cog):
             await interaction.followup.send("❌ No difficulties found!", ephemeral=True)
             return
         buttons = [(d["name"], discord.ButtonStyle.primary, f"difficulty_{d['name']}", 0) for d in diffs]
-        await self.send_or_update_embed(interaction, "⚖️ Select Difficulty", "Choose the dungeon difficulty.", buttons=buttons)
+        await self.send_or_update_embed(
+            interaction,
+            "⚖️ Select Difficulty",
+            "Choose the dungeon difficulty.",
+            buttons=buttons,
+            channel=channel,
+        )
 
     # ──────────────────────────────────────────────────────────────────
     # Intro slideshow embed

--- a/hub/hub_manager.py
+++ b/hub/hub_manager.py
@@ -108,7 +108,13 @@ class HubManager(commands.Cog):
             ephemeral=True
         )
 
-    async def post_lfg_post(self, interaction: discord.Interaction, thread: discord.Thread, session_id: int):
+    async def post_lfg_post(
+        self,
+        interaction: discord.Interaction,
+        thread: discord.Thread,
+        session_id: int,
+        difficulty: str,
+    ):
         """
         Posts an LFG (Join Game) message into the hub channel.
         """
@@ -126,6 +132,11 @@ class HubManager(commands.Cog):
                 "Once everyone has joined, this join message will be removed."
             ),
             color=discord.Color.green()
+        )
+        lfg_embed.add_field(
+            name="Difficulty",
+            value=f"**{difficulty}**",
+            inline=False
         )
         lfg_embed.set_footer(text=(
             f"Session Thread: {thread.name} | "


### PR DESCRIPTION
### Motivation
- Change the session setup sequencing so difficulty is chosen first, then the queue embed is created and the hub LFG post includes the chosen difficulty.
- Allow the LFG post to advertise session difficulty so joiners see relevant info before joining.
- Keep behavior safe: ensure only the session owner can set difficulty and avoid duplicate queue/LFG posting.
- Make the flow smooth so class selection and intro logic continue to work without breaking existing session lifecycle.

### Description
- Reordered session setup in `game/game_master.py`: `create_session` now shows difficulty selection in the private thread instead of immediately posting the queue/LFG.
- Added `handle_difficulty_selection` (in `game/game_master.py`) which updates the `sessions` DB row, marks the session as having posted the queue, logs the change, and then calls a new helper `send_queue_and_lfg` to post the queue embed and LFG announcement.
- Added `send_queue_and_lfg` (in `game/game_master.py`) to centralize posting the queue embed to the session thread and calling the hub to post the LFG message with difficulty.
- Updated embed sending to support targeting a specific channel: `send_difficulty_selection` gained an optional `channel` param and now forwards it to `send_or_update_embed` (`game/embed_manager.py`).
- Updated `HubManager.post_lfg_post` (`hub/hub_manager.py`) to accept a `difficulty` argument and include a `Difficulty` field in the LFG embed.
- Guarded difficulty selection so only the session owner can pick it and added a `queue_posted` flag on the in-memory session to prevent duplicates.
- Adjusted class-selection flow so when all classes are chosen the flow queries the stored difficulty and proceeds to `start_session`/intro as before. Also updated the interaction routing to call the new handler for `difficulty_` clicks.
- Modified files: `game/game_master.py`, `game/embed_manager.py`, `hub/hub_manager.py`.

### Testing
- No automated tests were executed for this change.
- (No test results to report.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944c58f1a808328a6582d4c9ac296ca)