### PR TITLE
Add `entrance` room template and starting-room support

### DIFF
--- a/database/database_setup.py
+++ b/database/database_setup.py
@@ -316,7 +316,8 @@ MERGED_ROOM_TEMPLATES: List[Tuple] = [
     (19, 'safe', 'Lake Room', 'You do not notice anything of importance, the area appears to be safe.', 'https://cdn.discordapp.com/attachments/1362832151485354065/1362832385829244948/Lake2.png?ex=680c65d0&is=680b1450&hm=bbf00040b5390f13ae4c8eedd2ea32dc08a0510e150879ae30cfc4b6e0a13ff0&', None, '2025-04-25 12:29:10', None, None),
     (20, 'safe', 'Lake Room 2', 'You do not notice anything of importance, the area appears to be safe.', 'https://cdn.discordapp.com/attachments/1362832151485354065/1362832386416443683/Lake3.png?ex=680c65d1&is=680b1451&hm=1dc65d458458bb0e73e417850bc66973c79921757193b7d85d5849923cb3624a&', None, '2025-04-25 12:29:10', None, None),
     (21, 'miniboss', 'Mimic', "As you approach the locked chest it springs to life and bares it's fangs!", 'https://cdn.discordapp.com/attachments/1362832151485354065/1365786181417177148/2.png?ex=68113600&is=680fe480&hm=a35ce81d097c19b34c06338bb678627ec9b16061ba867cb0d72be0d84075a927&', 16, '2025-04-29 00:24:47', None, None),
-    (22, 'death', 'Death', 'Your health as fallen to 0 and have fainted.', 'https://cdn.discordapp.com/attachments/1362832151485354065/1370837025665712178/output.gif?ex=6820f2f7&is=681fa177&hm=5c0ff142cc94ff7dd4050fb0be0cb1821580e251f6c5e8cb2f31384170afbd52&', None, '2025-05-09 16:59:31', None, None)
+    (22, 'death', 'Death', 'Your health as fallen to 0 and have fainted.', 'https://cdn.discordapp.com/attachments/1362832151485354065/1370837025665712178/output.gif?ex=6820f2f7&is=681fa177&hm=5c0ff142cc94ff7dd4050fb0be0cb1821580e251f6c5e8cb2f31384170afbd52&', None, '2025-05-09 16:59:31', None, None),
+    (23, 'entrance', 'Dungeon Entrance', 'You arrive at the dungeon entrance. The air is calm, and the path ahead beckons you forward.', 'https://the-demiurge.com/DemiDevUnit/images/backintro.png', None, '2025-06-23 12:00:00', None, None)
 ]
 
 # --- items --------------------------------------------------------------------
@@ -682,7 +683,7 @@ TABLES = {
             difficulty_name   VARCHAR(50) NOT NULL,
             floor_number      INT,
             room_type ENUM(
-                'safe','monster','item','shop','boss','trap','illusion',
+                'safe','entrance','monster','item','shop','boss','trap','illusion',
                 'staircase_up','staircase_down','exit','locked'
             ) NOT NULL,
             chance            FLOAT   NOT NULL,
@@ -920,7 +921,7 @@ TABLES = {
         CREATE TABLE IF NOT EXISTS room_templates (
             template_id   INT AUTO_INCREMENT PRIMARY KEY,
             room_type ENUM(
-                'safe','monster','item','shop','boss','trap','illusion',
+                'safe','entrance','monster','item','shop','boss','trap','illusion',
                 'staircase_up','staircase_down','exit','locked','chest_unlocked',
                 'miniboss','death'
             ) NOT NULL DEFAULT 'safe',

--- a/game/dungeon_generator.py
+++ b/game/dungeon_generator.py
@@ -175,7 +175,7 @@ class DungeonGenerator(commands.Cog):
                     """
                     SELECT template_id
                       FROM room_templates
-                     WHERE room_type NOT IN ('locked','safe','chest_unlocked','boss','exit','illusion')
+                     WHERE room_type NOT IN ('locked','safe','entrance','chest_unlocked','boss','exit','illusion')
                      ORDER BY RAND()
                      LIMIT 1
                     """
@@ -514,7 +514,7 @@ class DungeonGenerator(commands.Cog):
                 elif coord == exit_coord:
                     rtype = "exit"
                 elif coord == (start_x, start_y):
-                    rtype = "safe" if floor_number == 1 else "staircase_down"
+                    rtype = "entrance" if floor_number == 1 else "staircase_down"
                 elif coord in shop_positions:
                     rtype = "shop"
                 else:

--- a/game/game_master.py
+++ b/game/game_master.py
@@ -343,7 +343,7 @@ class GameMaster(commands.Cog):
                 FROM rooms
                 WHERE session_id = %s
                   AND floor_id = %s
-                  AND room_type = 'safe'
+                  AND room_type IN ('safe', 'entrance')
                 """,
                 (session.session_id, floor_id),
             )

--- a/utils/ui_helpers.py
+++ b/utils/ui_helpers.py
@@ -37,6 +37,7 @@ def get_emoji_for_room_type(room_type: str) -> str:
     """
     mapping = {
         "safe":           "🟩",
+        "entrance":       "🟩",
         "monster":        "🟥",
         "boss":           "💀",
         "illusion":       "🔮",


### PR DESCRIPTION
### Motivation
- Introduce a dedicated starting-room type so the dungeon entrance can have its own template (description + `image_url`) distinct from generic `safe` rooms.
- Ensure the generator and UI treat the starting room as a special but non-hostile room (safe-like) while preventing it from being used as an inner locked-room template.

### Description
- Add `entrance` to the DB enums for room placement rules and `room_templates`, and seed a `Dungeon Entrance` template in `MERGED_ROOM_TEMPLATES` (`database/database_setup.py`).
- Make the generator set the starting tile on floor 1 to `entrance` (`game/dungeon_generator.py`) and exclude `entrance` from candidates returned by `fetch_random_inner_template` so it won't be reused as an inner locked-room template.
- Treat `entrance` like a safe room in gameplay helpers: include it in the minimap emoji mapping (`utils/ui_helpers.py`) and in the safe-room teleport selection (`game/game_master.py`).
- Files changed: `database/database_setup.py`, `game/dungeon_generator.py`, `game/game_master.py`, `utils/ui_helpers.py`.

### Testing
- No automated tests were executed as part of this change (none requested).
- Manual verification recommended: generate a dungeon and confirm the starting tile has `room_type = 'entrance'`, the embed uses the `entrance` template `description`/`image_url`, and teleports/mini‑map treat it like a safe room.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944d10d60248328a9a242b8cf8c0d8c)