### PR TITLE
Add colored HP bars to embeds

### DIFF
--- a/game/battle_system.py
+++ b/game/battle_system.py
@@ -10,7 +10,13 @@ from utils.status_engine   import StatusEffectEngine
 from utils.ability_engine import AbilityEngine
 from utils.helpers import load_config
 from typing import Any, Dict, List, Optional, Set, Tuple
-from utils.ui_helpers import create_progress_bar, create_cooldown_bar, format_status_effects, get_emoji_for_room_type
+from utils.ui_helpers import (
+    create_cooldown_bar,
+    create_health_bar,
+    create_progress_bar,
+    format_status_effects,
+    get_emoji_for_room_type,
+)
 from models.session_models import SessionPlayerModel
 
 logger = logging.getLogger("BattleSystem")
@@ -41,14 +47,6 @@ class BattleSystem(commands.Cog):
             logger.error("DB connection error in BattleSystem: %s", e)
             raise
 
-    def create_bar(self, current: int, maximum: int, length: int = 10) -> str:
-        current = max(current, 0)
-        if maximum <= 0:
-            return "[No Data]"
-        filled = int(round(length * current / float(maximum)))
-        bar = "█" * filled + "░" * (length - filled)
-        return f"[{bar}] {current}/{maximum}"
-    
     def _normalize_se(self, raw: Dict[str,Any]) -> Dict[str,Any]:
         """
         Turn raw engine output into exactly the 3 keys our UI helper wants:
@@ -492,14 +490,14 @@ class BattleSystem(commands.Cog):
         eb = discord.Embed(title=title, color=color)
         # show enemy HP + effects
         enemy_line = format_status_effects(session.battle_state["enemy_effects"])
-        val = f"❤️ HP: {self.create_bar(enemy['hp'], enemy['max_hp'])}"
+        val = f"❤️ HP: {create_health_bar(enemy['hp'], enemy['max_hp'])}"
         if enemy_line:
             val += f" {enemy_line}"
         eb.add_field(name=f"Enemy: {enemy['enemy_name']}", value=val, inline=False)
 
         # show player HP + effects
         player_line = format_status_effects(session.battle_state["player_effects"])
-        stats_text = f"❤️ HP: {self.create_bar(player['hp'], player['max_hp'])}"
+        stats_text = f"❤️ HP: {create_health_bar(player['hp'], player['max_hp'])}"
         if player_line:
             stats_text += f" {player_line}"
         stats_text += f"\n⚔️ ATK: {player['attack_power']}\n🛡️ DEF: {player['defense']}"
@@ -567,13 +565,13 @@ class BattleSystem(commands.Cog):
 
         eb = discord.Embed(title=title, color=color)
         enemy_line  = format_status_effects(session.battle_state.get("enemy_effects", []))
-        val = f"❤️ HP: {self.create_bar(enemy['hp'], enemy['max_hp'])}"
+        val = f"❤️ HP: {create_health_bar(enemy['hp'], enemy['max_hp'])}"
         if enemy_line:
             val += f" {enemy_line}"
         eb.add_field(name=f"Enemy: {enemy['enemy_name']}", value=val, inline=False)
 
         player_line = format_status_effects(session.battle_state.get("player_effects", []))
-        stats_text = f"❤️ HP: {self.create_bar(player['hp'], player['max_hp'])}"
+        stats_text = f"❤️ HP: {create_health_bar(player['hp'], player['max_hp'])}"
         if player_line:
             stats_text += f" {player_line}"
         stats_text += (

--- a/game/embed_manager.py
+++ b/game/embed_manager.py
@@ -14,6 +14,7 @@ from models.database import Database
 from utils.helpers import load_config
 from utils.ui_helpers import (
     create_cooldown_bar,
+    create_health_bar,
     create_progress_bar,
     get_emoji_for_room_type,
     format_status_effects,
@@ -597,12 +598,9 @@ class EmbedManager(commands.Cog):
     # Boss battle embed
     # ──────────────────────────────────────────────────────────────────
     async def send_boss_embed(self, interaction: discord.Interaction, boss_info: Dict[str, Any], battle_log: str):
-        def bar(cur: int, max_: int, length: int = 10) -> str:
-            filled = int(round(length * cur / float(max_))) if max_ else 0
-            return f"[{'█'*filled}{'░'*(length-filled)}] {cur}/{max_}"
         desc = (
             f"{boss_info.get('description','A fearsome boss stands before you.')}\n\n"
-            f"**Boss HP:** {bar(boss_info['hp'], boss_info['max_hp'])}\n\n{battle_log}"
+            f"**Boss HP:** {create_health_bar(boss_info['hp'], boss_info['max_hp'])}\n\n{battle_log}"
         )
         embed = discord.Embed(title=f"🔥 Boss Battle: {boss_info['enemy_name']}", description=desc, color=discord.Color.dark_orange())
         if boss_info.get("image_url"):

--- a/game/game_master.py
+++ b/game/game_master.py
@@ -15,7 +15,7 @@ from discord.ext import commands
 import mysql.connector
 from utils.status_engine  import StatusEffectEngine
 from utils.helpers        import load_config
-from utils.ui_helpers     import get_emoji_for_room_type  # For minimap icons, if needed
+from utils.ui_helpers     import create_health_bar, get_emoji_for_room_type  # For minimap icons, if needed
 from core.game_session    import GameSession
 from models.session_models import (
     SessionModel,
@@ -1141,16 +1141,10 @@ class GameMaster(commands.Cog):
             visible
         )
 
-        def _bar(curr, mx, ln=10):
-            if not mx:
-                return "[-]"
-            filled = int(round(ln * curr / mx))
-            return f"[{'█'*filled}{'░'*(ln-filled)}] {curr}/{mx}"
-
         header = ""
         if p:
             # 1) HP bar
-            header += f"**HP:** {_bar(p['hp'], p['max_hp'])}\n"
+            header += f"**HP:** {create_health_bar(p['hp'], p['max_hp'])}\n"
 
             # 2) Status‐effects line (one per effect)
             from utils.ui_helpers import format_status_effects
@@ -1934,7 +1928,7 @@ class GameMaster(commands.Cog):
         conn.close()
 
         xp_bar = _bar(pd["experience"], nxt["required_exp"] if nxt else None)
-        hp_bar = _bar(pd["hp"], pd["max_hp"])
+        hp_bar = create_health_bar(pd["hp"], pd["max_hp"])
 
         c_name  = ClassModel.get_class_name(pd["class_id"]) or "Unknown"
         c_thumb = ClassModel.get_class_image_url(pd["class_id"])

--- a/utils/ui_helpers.py
+++ b/utils/ui_helpers.py
@@ -30,6 +30,31 @@ def create_cooldown_bar(current_cd: float, max_cd: float, length: int = 10) -> s
     return f"[{bar}]"
 
 
+def create_health_bar(current: int, maximum: int, length: int = 10) -> str:
+    """
+    Build a colored health bar using square emojis and percentage thresholds.
+    """
+    if maximum <= 0:
+        return "[No Data]"
+
+    current = max(0, min(current, maximum))
+    percent = current / float(maximum)
+
+    if percent >= 0.75:
+        fill = "🟩"
+    elif percent >= 0.50:
+        fill = "🟨"
+    elif percent >= 0.25:
+        fill = "🟧"
+    else:
+        fill = "🟥"
+
+    filled = int(round(length * percent))
+    empty = "⬛"
+    bar = f"{fill * filled}{empty * (length - filled)}"
+    return f"[{bar}] {current}/{maximum}"
+
+
 def get_emoji_for_room_type(room_type: str) -> str:
     """
     Return an emoji representing the supplied room type (case‑insensitive).


### PR DESCRIPTION
### Motivation
- Improve visual clarity of HP for players and enemies by adding color-coded health bars to embeds.
- Convey health warning states at a glance (green → yellow → orange → red) based on HP percentage thresholds.
- Use a single shared helper so all embed consumers render the same visual style.

### Description
- Add `create_health_bar(current, maximum, length=10)` to `utils/ui_helpers.py`. It renders a bar of colored square emojis with thresholds: `>=75%` green (`🟩`), `50–74%` yellow (`🟨`), `25–49%` orange (`🟧`), `<25%` red (`🟥`), with empty slots as `⬛` and a trailing `current/maximum` text.
- Replace existing textual/ASCII HP bar usage with the new helper in the following places:
  - `game/battle_system.py` — enemy and player HP lines in battle embeds now use `create_health_bar`.
  - `game/embed_manager.py` — boss embed HP display updated to use `create_health_bar`.
  - `game/game_master.py` — room header and character sheet HP displays updated to use `create_health_bar`.
- Updated imports where needed and removed local/duplicated bar rendering where replaced by the shared helper.

### Testing
- No automated tests were run against these changes.
- (No unit/integration test runs reported.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694550e327608328ae1504a1cfe1762a)