### PR TITLE
Add explicit enter flow for illusion trials

### DIFF
--- a/game/embed_manager.py
+++ b/game/embed_manager.py
@@ -650,7 +650,7 @@ class EmbedManager(commands.Cog):
             if room_info.get("image_url"):
                 embed.set_image(url=f"{room_info['image_url']}?t={int(time.time())}")
             buttons = [
-                ("Skill", discord.ButtonStyle.primary, "action_skill", 0),
+                ("Enter Room", discord.ButtonStyle.primary, "action_enter_illusion", 0),
                 ("Menu", discord.ButtonStyle.secondary, "action_menu", 0),
             ]
             await self.send_or_update_embed(interaction, _ZWSP, _ZWSP, embed_override=embed, buttons=buttons)


### PR DESCRIPTION
### Motivation

- Prevent illusion trials from auto-starting when a player merely views an illusion room so the player can choose to `Enter Room` first.
- Provide a clear UI affordance to start an illusion trial and reduce surprising state changes during room refresh.
- Ensure the trial state is explicitly initialised and validated before allowing `action_skill` interactions to affect a trial.

### Description

- Update `EmbedManager.send_illusion_embed` to show an `Enter Room` button (`action_enter_illusion`) when no active `challenge_state.sequence` exists, and only show the trial/crystal view when a challenge state is present.
- Add `GameMaster.action_enter_illusion` which validates the session and room, calls `_ensure_illusion_state` to initialise the trial state, and refreshes the view via `SessionManager.refresh_current_state`.
- Change the room refresh and skill handling logic to read the pre-existing `session.illusion_states` entry instead of always calling `_ensure_illusion_state`, and clear mismatched state when room IDs differ to avoid auto-starting trials.
- Wire the new button by handling `cid == "action_enter_illusion"` in the main interaction dispatch to call `action_enter_illusion`.

### Testing

- No automated tests were run against these changes.
- Functional validation was not executed as part of this PR (no CI/test run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945fa3f84f88328a253a71ee1051f70)