### PR TITLE
Add illusion battle embed and Leave Room action

### DIFF
--- a/game/embed_manager.py
+++ b/game/embed_manager.py
@@ -680,6 +680,69 @@ class EmbedManager(commands.Cog):
         ]
         await self.send_or_update_embed(interaction, _ZWSP, _ZWSP, embed_override=embed, buttons=buttons)
 
+    # ──────────────────────────────────────────────────────────────────
+    # Illusion battle-like embed
+    # ──────────────────────────────────────────────────────────────────
+    async def send_illusion_battle_embed(
+        self,
+        interaction: discord.Interaction,
+        room_info: Dict[str, Any],
+        challenge_state: Dict[str, Any],
+        player_status: Dict[str, Any],
+        battle_log: List[str],
+    ):
+        sequence = challenge_state["sequence"]
+        current_index = challenge_state.get("current_index", 0)
+        failures = challenge_state.get("failures", 0)
+        crystal_hp = challenge_state.get("crystal_hp") or [999 for _ in range(len(sequence))]
+        if len(crystal_hp) != len(sequence):
+            crystal_hp = [999 for _ in range(len(sequence))]
+
+        total_steps = len(sequence)
+        crystal = sequence[current_index]
+        current_hp = crystal_hp[current_index]
+
+        embed = discord.Embed(
+            title=f"🔮 Illusion Battle ({current_index + 1}/{total_steps})",
+            description=(
+                "The crystal surges with hostile energy.\n"
+                "Strike it with the opposing element to shatter the illusion."
+            ),
+            color=discord.Color.purple(),
+        )
+        if crystal.get("image_url"):
+            embed.set_image(url=f"{crystal['image_url']}?t={int(time.time())}")
+        elif room_info.get("image_url"):
+            embed.set_image(url=f"{room_info['image_url']}?t={int(time.time())}")
+
+        crystal_value = (
+            f"❤️ HP: {create_health_bar(current_hp, 999)}\n"
+            f"✨ Element: {crystal.get('element_name', 'Unknown')}\n"
+            f"Failures: {failures}/2"
+        )
+        embed.add_field(name=f"Crystal: {crystal.get('name', 'Unknown')}", value=crystal_value, inline=False)
+
+        stats_text = (
+            f"❤️ HP: {create_health_bar(player_status['hp'], player_status['max_hp'])}\n"
+            f"⚔️ ATK: {player_status['attack_power']}\n"
+            f"🛡️ DEF: {player_status['defense']}"
+        )
+        embed.add_field(name="Your Stats", value=stats_text, inline=False)
+
+        embed.add_field(
+            name="Battle Log",
+            value="\n".join(battle_log[-5:]) or "The crystal awaits your strike.",
+            inline=False,
+        )
+
+        buttons = [
+            ("Skill", discord.ButtonStyle.primary, "action_skill", 0),
+            ("Use", discord.ButtonStyle.success, "action_use", 0),
+            ("Leave Room", discord.ButtonStyle.secondary, "action_leave_room", 0),
+            ("Menu", discord.ButtonStyle.secondary, "action_menu", 0),
+        ]
+        await self.send_or_update_embed(interaction, _ZWSP, _ZWSP, embed_override=embed, buttons=buttons)
+
 
 async def setup(bot: commands.Bot):
     await bot.add_cog(EmbedManager(bot))


### PR DESCRIPTION
### Motivation

- Present illusion trials in a more battle-like UI so players can see crystal HP, element and a log similar to combat views.
- Reuse existing status/health helpers to keep the look consistent with other battle embeds.
- Allow players to exit an active illusion without finishing it via a "Leave Room" action.

### Description

- Added `send_illusion_battle_embed` to `game/embed_manager.py`. It mirrors the battle layout and uses `create_health_bar` to display the crystal HP (999) and the player's HP; shows element, failures and a short battle log.
- Updated `SessionManager.refresh_current_state` (`game/session_manager.py`) to render the new illusion battle embed when the player is inside an active illusion trial (passes `player_status` and `session.game_log` to the embed).
- Added `action_leave_room` in `game/game_master.py` to handle a new `action_leave_room` button: it logs the retreat, clears the illusion state, teleports the player to a safe room, and refreshes the view.
- Wired the new custom_id `action_leave_room` into the component router so the button triggers the new handler and added the `Leave Room` button to the illusion battle embed.

### Testing

- Automated tests: none were run.
- Changes were committed locally; no CI/test execution was performed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945fb2ed650832883c4463d77996ca5)