### PR TITLE
Show victory embed during session refresh

### DIFF
--- a/game/session_manager.py
+++ b/game/session_manager.py
@@ -278,6 +278,12 @@ class SessionManager(commands.Cog):
             return await interaction.followup.send("❌ No active session found.", ephemeral=True)
 
         if getattr(session, "victory_pending", False):
+            if not getattr(session, "victory_embed_sent", False) and session.last_victory_enemy:
+                bs = self.bot.get_cog("BattleSystem")
+                if bs:
+                    return await bs.display_victory_embed(
+                        interaction, session, session.last_victory_enemy
+                    )
             if not interaction.response.is_done():
                 await interaction.response.defer()
             return


### PR DESCRIPTION
### Motivation
- A race condition left a session with `victory_pending` set but the victory embed never displayed when `refresh_current_state` ran, so players saw the room flip without the Victory UI.
- The code previously always deferred the interaction when `victory_pending` was true, preventing the cached victory data from being rendered.

### Description
- Added a pre-defer check in `refresh_current_state` to detect `victory_pending` and `not victory_embed_sent` and use `session.last_victory_enemy` to render the victory UI.
- The new logic obtains the `BattleSystem` cog and calls `bs.display_victory_embed(interaction, session, session.last_victory_enemy)` when appropriate, returning early after rendering.
- If the embed has already been sent the method retains the previous behavior of deferring the interaction and returning.

### Testing
- No automated tests were run against this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694607e6a5688328bed171c23fb3566c)