### PR TITLE
Show main menu buttons in illusion rooms

### DIFF
--- a/game/embed_manager.py
+++ b/game/embed_manager.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import time
 from typing import Any, Dict, List, Optional, Set, Tuple
@@ -649,10 +650,14 @@ class EmbedManager(commands.Cog):
             )
             if room_info.get("image_url"):
                 embed.set_image(url=f"{room_info['image_url']}?t={int(time.time())}")
-            buttons = [
-                ("Enter Room", discord.ButtonStyle.primary, "action_enter_illusion", 0),
-                ("Menu", discord.ButtonStyle.secondary, "action_menu", 0),
-            ]
+            exits = room_info.get("exits")
+            if isinstance(exits, str):
+                try:
+                    exits = json.loads(exits)
+                except json.JSONDecodeError:
+                    exits = None
+            buttons = self.get_main_menu_buttons(directions=exits)
+            buttons.append(("Enter Room", discord.ButtonStyle.primary, "action_enter_illusion", 2, False))
             await self.send_or_update_embed(interaction, _ZWSP, _ZWSP, embed_override=embed, buttons=buttons)
             return
 


### PR DESCRIPTION
### Motivation
- Make illusion-room embeds behave like safe rooms by showing the standard navigation and action buttons before a player enters the trial.
- Keep the `Enter Room` action available as an explicit extra control while allowing movement and other main actions.
- Ensure movement buttons reflect the room `exits` even when stored as a JSON string in `room_info`.

### Description
- Added an `import json` and parse `room_info['exits']` when it is a string to obtain `directions` for building movement buttons.
- Replaced the minimal illusion pre-trial button set with a call to `get_main_menu_buttons(directions=exits)` so standard navigation and action rows are shown.
- Appended the `Enter Room` button to the returned main-menu button list so the trial can still be entered via `action_enter_illusion`.
- Changes are confined to `send_illusion_embed` in `game/embed_manager.py` and preserve existing trial/embed behavior when `challenge_state` is present.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69460cf9dd048328ba441c5ebba62781)