### PR TITLE
Include illusion rooms in skill-menu battle filtering

### DIFF
--- a/game/battle_system.py
+++ b/game/battle_system.py
@@ -639,6 +639,8 @@ class BattleSystem(commands.Cog):
 
         pid = session.current_turn
         in_battle = bool(session.battle_state)
+        gm = self.bot.get_cog("GameMaster")
+        in_illusion = bool(gm and gm.is_player_in_illusion(session, pid))
 
         # fetch class & level
         from models.session_models import SessionPlayerModel
@@ -697,7 +699,7 @@ class BattleSystem(commands.Cog):
         conn.close()
 
         # filter by context
-        allowed = {"self", "any"} | ({"enemy"} if in_battle else {"ally"})
+        allowed = {"self", "any"} | ({"enemy"} if (in_battle or in_illusion) else {"ally"})
         abilities = [a for a in abilities if a["target_type"] in allowed]
         temp_abilities = [a for a in temp_abilities if a["target_type"] in allowed]
 


### PR DESCRIPTION
### Motivation
- The skill menu shown inside crystal shard / illusion room sequences only displayed out-of-battle abilities and omitted enemy-target (in-battle) skills, making the illusion mechanic inconsistent with combat.

### Description
- Updated `handle_skill_menu` in `game/battle_system.py` to obtain the `GameMaster` and compute `in_illusion` via `is_player_in_illusion(session, pid)`.
- Changed the allowed-targets filter so that enemy-target abilities are included when `(in_battle or in_illusion)` is true.
- The same context-aware filter now applies to both class abilities and temporary abilities before rendering the skill menu.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69460de27bcc83288a8d7789c2685b89)