### PR TITLE
Clarify illusion-room leave message to mention crystal teleportation

### DIFF
--- a/game/game_master.py
+++ b/game/game_master.py
@@ -501,7 +501,7 @@ class GameMaster(commands.Cog):
 
         self.append_game_log(
             session.session_id,
-            "You retreat from the illusion chamber."
+            "The dungeon shifts, you have been sent to a new location via the crystal's teleport magicks."
         )
         self._clear_illusion_state(session, session.current_turn)
         await self._teleport_player_to_safe_room(interaction, session, room["floor_id"])


### PR DESCRIPTION
### Motivation
- Make the feedback clearer when a player leaves an illusion/crystal chamber by indicating they were teleported by the crystal.
- Replace the ambiguous retreat message with an explicit description of the teleport magicks to improve player understanding.

### Description
- Update the message passed to `append_game_log` in `GameMaster.action_leave_room` to: `"The dungeon shifts, you have been sent to a new location via the crystal's teleport magicks."`.
- Change was made in `game/game_master.py` as a one-line string replacement where the illusion leave flow calls `append_game_log`.

### Testing
- No automated tests were run for this change.
- CI/unit test pipelines were not executed as part of this edit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69460ee4d4bc8328ba8a56796aee2a85)