### PR TITLE
Avoid duplicate "Difficulty set" log on session start

### DIFF
--- a/game/game_master.py
+++ b/game/game_master.py
@@ -854,10 +854,6 @@ class GameMaster(commands.Cog):
             "steps": self.fetch_intro_steps(),
             "current_index": 0
         }
-        self.append_game_log(
-            session.session_id,
-            f"Difficulty set to **{difficulty}**."
-        )
         await self.begin_intro_sequence(interaction, interaction.channel.id)
 
     # ────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation

- The game log showed the message `Difficulty set to **{difficulty}**.` twice when a session began because it was being appended in multiple places.
- This resulted in duplicate difficulty text appearing in the starting-room log and UI.

### Description

- Removed the redundant call to `append_game_log(session.session_id, f"Difficulty set to **{difficulty}**.")` from `start_session` in `game/game_master.py`.
- The difficulty is still persisted to the DB and the intro flow is unchanged; only the duplicate logging call was removed.

### Testing

- No automated tests were run for this change.
- The change was committed to the repository as `game/game_master.py` only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946178574b08328b64c4675d4b684c0)