### PR TITLE
Use flat damage for Needles abilities

### DIFF
--- a/database/database_setup.py
+++ b/database/database_setup.py
@@ -142,8 +142,8 @@ MERGED_ABILITIES: List[Tuple] = [
     (89, 'Mighty Guard', None, '{"barrier": {"duration": 3}}', 0, '🛡️🔼', 'self', None, None, 12, 3, '2025-05-14 01:44:27', 'attack_power'),
     (90, 'Blue Bullet', None, '{"base_damage": 100}', 0, '⚔️', 'enemy', None, None, None, None, '2025-05-14 01:45:27', 'attack_power'),
     (91, 'Karma', 'Deals Damage based on turn amount', '{"karma": true}', 3, None, 'any', None, None, None, None, '2025-05-16 16:13:30', 'attack_power'),
-    (92, '50 Needles', 'Deals 50 damage with 100% hit rate and ignores defense.', '{"base_damage": 47}', 0, None, 'any', None, None, None, None, '2025-05-22 15:21:04', 'attack_power'),
-    (93, '1,000 Needles', 'Deals 1,000 damage with 100% hit rate and ignores defense.', '{"base_damage": 1000}', 0, None, 'any', None, None, None, None, '2025-05-22 15:21:04', 'attack_power')
+    (92, '50 Needles', 'Deals 50 damage with 100% hit rate and ignores defense.', '{"flat_damage": 50}', 0, None, 'any', None, None, None, None, '2025-05-22 15:21:04', 'attack_power'),
+    (93, '1,000 Needles', 'Deals 1,000 damage with 100% hit rate and ignores defense.', '{"flat_damage": 1000}', 0, None, 'any', None, None, None, None, '2025-05-22 15:21:04', 'attack_power')
 ]
 
 # --- ability ↔ status‑effects -------------------------------------------------


### PR DESCRIPTION
### Motivation
- Needles abilities should deal a fixed, defense‑ignoring amount of damage rather than being processed by the stat/ratio damage formula and variance.  
- The seed data used `base_damage` which caused those abilities to be handled by the JRPG scaling logic and introduced jitter.  
- The engine already supports a `flat_damage` payload, so the fix is to update the stored ability payloads.  
- Keep runtime logic unchanged and align database seed/dump with the intended behavior.

### Description
- Replaced the JSON payload for `50 Needles` (ability id `92`) to use `{"flat_damage": 50}` in `database/database_setup.py`.  
- Replaced the JSON payload for `1,000 Needles` (ability id `93`) to use `{"flat_damage": 1000}` in `database/database_setup.py`.  
- Synchronized the SQL dump by updating `dump-adventure-202512190230.sql` to the same `flat_damage` payloads.  
- No changes were made to `utils/ability_engine.py` since it already handles `flat_damage` keys.

### Testing
- No automated tests were run for this data-only change.  
- Files modified: `database/database_setup.py` and `dump-adventure-202512190230.sql`.  
- Changes were committed successfully to the repository.  
- Because this is a seed/data update, confirm behavior in a runtime environment if further validation is desired.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69461bf860888328b59895a38a1fd96a)