### PR TITLE
Add ephemeral hub notice after creating new game thread

### DIFF
--- a/game/game_master.py
+++ b/game/game_master.py
@@ -748,6 +748,13 @@ class GameMaster(commands.Cog):
             await interaction.followup.send(
                 "❌ EmbedManager unavailable.", ephemeral=True
             )
+        await interaction.followup.send(
+            (
+                "✅ Your private game thread is ready. "
+                f"Click {thread.mention} in the channel list to start setup."
+            ),
+            ephemeral=True
+        )
 
     async def send_queue_and_lfg(self,
                                  interaction: discord.Interaction,
@@ -2385,8 +2392,7 @@ class GameMaster(commands.Cog):
         
         # New Game button in hub → create session
         if cid == "setup_new_game":
-            # ACK the button silently (no ephemeral, no new message)
-            await interaction.response.defer()
+            await interaction.response.defer(ephemeral=True)
             await self.create_session(interaction, max_slots=6)
             return
         # ─── “End My Turn” on death (multiplayer) ───────────────────


### PR DESCRIPTION
### Motivation
- Provide ephemeral feedback in the hub when a player creates a private game thread so they know where to continue setup.
- Ensure the New Game button acknowledges the interaction in a way that surfaces a private confirmation to the initiating user.

### Description
- Change the `setup_new_game` interaction handling to call `interaction.response.defer(ephemeral=True)` so the ACK is ephemeral.
- After a session is created in `create_session`, send an ephemeral followup with `interaction.followup.send` that mentions the new thread via `thread.mention` to instruct the user to open it. 
- All edits are contained in `game/game_master.py`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69461f4a723883288bae5635c75e869c)