### PR TITLE
Persist joining players to DB so queue and class selection reflect joins

### DIFF
--- a/game/session_manager.py
+++ b/game/session_manager.py
@@ -208,6 +208,7 @@ class SessionManager(commands.Cog):
                 "⚠️ You’ve already joined this session!", ephemeral=True
             )
         try:
+                SessionPlayerModel.add_player(session_id, user.id, user.display_name)
                 session.add_player(user.id)
                 SessionModel.increment_player_count(session_id)
                 session.players = SessionPlayerModel.get_players(session_id)


### PR DESCRIPTION
### Motivation
- Ensure players who click “Join” are persisted to the `session_players` table so the queue embed reflects live joins. 
- Make joined players available to class selection and session startup logic that reads from DB-backed player state. 
- Ensure joined players are incorporated into the in-memory `GameSession` turn order for multiplayer gameplay. 
- Fix a gap where the owner was being inserted into DB on session creation but joining players were not.

### Description
- Added a call to `SessionPlayerModel.add_player(session_id, user.id, user.display_name)` inside `SessionManager.join_session` before updating the in-memory session with `session.add_player(user.id)` so the DB and memory stay in sync. 
- After inserting the player, the code still increments the session player count via `SessionModel.increment_player_count` and refreshes `session.players` from `SessionPlayerModel.get_players(session_id)`. 
- The change is localized to `game/session_manager.py` and preserves existing behavior of adding the user to the thread via `th.add_user(user)`. 
- This enables `GameMaster.build_queue_embed` / `GameMaster.update_queue_embed` and class selection checks (which read player state from DB) to include newly joined players.

### Testing
- No automated tests were executed as part of this change. 
- Unit/CI tests have not been run in this rollout and should be executed in CI to validate DB writes and queue embed updates. 
- Manual inspection and local logging confirmed the DB insert call and subsequent in-memory update are present in `game/session_manager.py`. 
- Recommend adding automated tests for `join_session` to assert DB insertion, `session.players` update, and `GameMaster.update_queue_embed` behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694622c3739083289e7a70998cea372c)