### PR TITLE
Add Summoner/Eidolon system: cloisters, DB schema, MP & summon flow

### DIFF
--- a/game/dungeon_generator.py
+++ b/game/dungeon_generator.py
@@ -155,7 +155,7 @@ class DungeonGenerator(commands.Cog):
             with conn.cursor(dictionary=True) as cur:
                 cur.execute(
                     """
-                    SELECT template_id, description, image_url, default_enemy_id
+                    SELECT template_id, description, image_url, default_enemy_id, eidolon_id, attune_level
                       FROM room_templates
                      WHERE room_type=%s
                      ORDER BY RAND()
@@ -175,7 +175,7 @@ class DungeonGenerator(commands.Cog):
                     """
                     SELECT template_id
                       FROM room_templates
-                     WHERE room_type NOT IN ('locked','safe','entrance','chest_unlocked','boss','exit','illusion')
+                     WHERE room_type NOT IN ('locked','safe','entrance','chest_unlocked','boss','exit','illusion','cloister')
                      ORDER BY RAND()
                      LIMIT 1
                     """
@@ -627,13 +627,16 @@ class DungeonGenerator(commands.Cog):
                 desc = tmpl.get("description", "A mysterious room…")
                 img  = tmpl.get("image_url")
                 def_en = tmpl.get("default_enemy_id")
+                eidolon_id = tmpl.get("eidolon_id")
+                attune_level = tmpl.get("attune_level")
 
                 with conn.cursor() as cur:
                     cur.execute(
                         "INSERT INTO rooms "
                         "(session_id,floor_id,coord_x,coord_y,description,room_type,"
-                        " image_url,default_enemy_id,exits,vendor_id,inner_template_id) "
-                        "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,NULL)",
+                        " image_url,default_enemy_id,exits,vendor_id,inner_template_id,"
+                        " eidolon_id,attune_level) "
+                        "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,NULL,%s,%s)",
                         (
                             session_id,
                             basement_floor_id,
@@ -643,7 +646,9 @@ class DungeonGenerator(commands.Cog):
                             img,
                             def_en,
                             json.dumps(exits),
-                            vendor_id
+                            vendor_id,
+                            eidolon_id,
+                            attune_level,
                         ),
                     )
             conn.commit()
@@ -724,6 +729,8 @@ class DungeonGenerator(commands.Cog):
             tmpl = self.fetch_random_template(rtype) or {}
             desc = tmpl.get("description", "A mysterious room…")
             img  = tmpl.get("image_url")
+            eidolon_id = tmpl.get("eidolon_id")
+            attune_level = tmpl.get("attune_level")
 
             if rtype == "boss":
                 with conn.cursor(dictionary=True) as cur2:
@@ -741,13 +748,14 @@ class DungeonGenerator(commands.Cog):
                     "INSERT INTO rooms "
                     "(session_id,floor_id,coord_x,coord_y,description,room_type,"
                     " image_url,default_enemy_id,exits,vendor_id,inner_template_id,"
-                    " stair_down_floor_id,stair_down_x,stair_down_y) "
-                    "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)",
+                    " stair_down_floor_id,stair_down_x,stair_down_y,eidolon_id,attune_level) "
+                    "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)",
                     (
                         session_id, first_floor_id, x, y,
                         desc, rtype, img, def_en,
                         json.dumps(exits), vendor_id, inner_id,
                         stair_down_floor_id, stair_down_x, stair_down_y,
+                        eidolon_id, attune_level,
                     ),
                 )
                 rid = cur.lastrowid
@@ -936,6 +944,8 @@ class DungeonGenerator(commands.Cog):
                 tmpl = self.fetch_random_template(rtype) or {}
                 desc = tmpl.get("description") or "A mysterious room..."
                 img  = tmpl.get("image_url")
+                eidolon_id = tmpl.get("eidolon_id")
+                attune_level = tmpl.get("attune_level")
 
                 if rtype in ("miniboss","boss","monster"):
                     role = "miniboss" if rtype=="miniboss" else ("boss" if rtype=="boss" else "normal")
@@ -951,9 +961,9 @@ class DungeonGenerator(commands.Cog):
 
                 with conn.cursor() as cur:
                     cur.execute(
-                        "INSERT INTO rooms (session_id, floor_id, coord_x, coord_y, description, room_type, image_url, default_enemy_id, exits, vendor_id, inner_template_id) "
-                        "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)",
-                        (session_id, floor_id, x, y, desc, rtype, img, def_en, json.dumps(exits), vendor_id, inner_id),
+                        "INSERT INTO rooms (session_id, floor_id, coord_x, coord_y, description, room_type, image_url, default_enemy_id, exits, vendor_id, inner_template_id, eidolon_id, attune_level) "
+                        "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)",
+                        (session_id, floor_id, x, y, desc, rtype, img, def_en, json.dumps(exits), vendor_id, inner_id, eidolon_id, attune_level),
                     )
                     room_id = cur.lastrowid
                     if rtype == "item":

--- a/game/embed_manager.py
+++ b/game/embed_manager.py
@@ -534,6 +534,7 @@ class EmbedManager(commands.Cog):
         directions: Optional[List[str]] = None,
         include_shop: bool = False,
         vendor_id: Optional[int] = None,
+        include_summon: bool = False,
         is_item: bool = False,
         is_locked: bool = False,
         has_key: bool = False,
@@ -584,6 +585,8 @@ class EmbedManager(commands.Cog):
         btns.extend(action_row)
 
         # ── Row 2: shop / unlock / stairs (optional) ────────────
+        if include_summon:
+            btns.append(("Summon", discord.ButtonStyle.primary, "action_summon", 2, False))
         if include_shop and vendor_id is not None:
             btns.append(("Shop", discord.ButtonStyle.secondary, f"action_shop_{vendor_id}", 2, False))
         if is_locked and has_key:

--- a/utils/ui_helpers.py
+++ b/utils/ui_helpers.py
@@ -75,6 +75,7 @@ def get_emoji_for_room_type(room_type: str) -> str:
         "staircase_up":   "🔼",
         "staircase_down": "🔽",
         "trap":           "🟧",
+        "cloister":       "🧿",
     }
     if not room_type:
         return "⬛"


### PR DESCRIPTION
### Motivation
- Implement a Final Fantasy–style Summoner progression where Summoners attune to Aetheryte cloisters to unlock Eidolons behind level requirements.
- Persist Eidolon metadata, per‑player unlocks and abilities, and add Summoner MP so summons and Eidolon abilities can consume resources.
- Ensure the database setup script can apply the new schema/seed data and perform non‑destructive migrations on existing installs.

### Description
- Database: added migration helpers `ensure_column`/`ensure_enum_values` and new tables `eidolons`, `eidolon_abilities`, and `player_eidolons` plus seed rows (`MERGED_EIDOLONS`) and `MERGED_EIDOLON_ABILITY_DEFS` in `database/database_setup.py` and updated `TABLE_ORDER`/seed insert logic. 
- Dungeon & rooms: added a new `cloister` room type, linked `room_templates`/`rooms` to an `eidolon_id` and `attune_level`, and updated `game/dungeon_generator.py` to carry those fields into generated rooms. 
- Gameplay & UI: wired Summon/Attune flows and UI holistically by adding Summon buttons and checks in `game/embed_manager.py` and `game/game_master.py`, a Summon menu and Eidolon ability flow in `game/battle_system.py`, and an `action_attune_*` handler that starts the Eidolon battle when a Summoner meets the level requirement. 
- Player data & rules: added MP support and helpers in `models/session_models.py` and `utils/stat_levelup.py`, MP item effects in `game/inventory_shop.py`, Eidolon unlock/XP logic and per‑turn summon/recall state handling (summon once per turn, recalled at turn end), and adjusted XP sharing so Eidolons gain 75% of enemy XP in `game/battle_system.py`.

### Testing
- No automated tests were run for this change (no CI/test suite executed as part of this rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69462fcd0d8883288f93714132874fec)