### PR TITLE
Seed element oppositions by element name to avoid FK mismatches

### DIFF
--- a/database/database_setup.py
+++ b/database/database_setup.py
@@ -320,15 +320,15 @@ MERGED_ELEMENTS: List[Tuple] = [
 ]
 
 # --- element oppositions ------------------------------------------------------
-MERGED_ELEMENT_OPPOSITIONS: List[Tuple] = [
-    (1, 1, 2),
-    (2, 2, 1),
-    (3, 3, 4),
-    (4, 4, 3),
-    (5, 5, 8),
-    (6, 6, 7),
-    (7, 7, 6),
-    (8, 8, 5)
+MERGED_ELEMENT_OPPOSITIONS: List[Tuple[str, str]] = [
+    ("Fire", "Ice"),
+    ("Ice", "Fire"),
+    ("Holy", "Death"),
+    ("Death", "Holy"),
+    ("Air", "Earth"),
+    ("Lightning", "Water"),
+    ("Water", "Lightning"),
+    ("Earth", "Air")
 ]
 
 # --- difficulties -------------------------------------------------------------
@@ -1576,9 +1576,13 @@ def insert_element_oppositions(cur):
         """
         INSERT INTO element_oppositions
           (element_id, opposing_element_id)
-        VALUES (%s, %s)
+        SELECT e.element_id, o.element_id
+        FROM elements e
+        JOIN elements o
+          ON e.element_name = %s
+         AND o.element_name = %s
         """,
-        [row[1:] for row in MERGED_ELEMENT_OPPOSITIONS]
+        MERGED_ELEMENT_OPPOSITIONS
     )
     logger.info("Inserted element_oppositions.")
 


### PR DESCRIPTION
### Motivation
- Fix a foreign-key mismatch when seeding `element_oppositions` that occurred from using hard-coded element IDs. 
- Ensure oppositions are inserted reliably even if `elements` IDs differ between databases or imports.

### Description
- Updated `MERGED_ELEMENT_OPPOSITIONS` to use element names (`List[Tuple[str,str]]`) instead of numeric IDs. 
- Rewrote `insert_element_oppositions` to insert by selecting `element_id` values via a `JOIN` on `elements.element_name` so the correct IDs are resolved at insert time. 
- All changes were made in `database/database_setup.py` and preserve the existing empty-table guard before seeding.

### Testing
- No automated tests were run for this change.
- Manual verification was not recorded in automated test logs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946c3d1aaf88328b6a1345c113f15c4)