### PR TITLE
Fix item_effects foreign key syntax

### DIFF
--- a/database/database_setup.py
+++ b/database/database_setup.py
@@ -1427,7 +1427,7 @@ TABLES = {
             effect_id INT NOT NULL,
             PRIMARY KEY (item_id, effect_id),
             FOREIGN KEY (item_id)  REFERENCES items(item_id)  ON DELETE CASCADE,
-            FOREIGN KEY (effect_id)REFERENCES status_effects(effect_id)ON DELETE CASCADE
+            FOREIGN KEY (effect_id) REFERENCES status_effects(effect_id) ON DELETE CASCADE
         )
     ''',
     # ---------- hub_embeds ----------


### PR DESCRIPTION
### Motivation

- The database setup script contained a malformed foreign key clause that could prevent MySQL from parsing the `item_effects` table definition.
- The change aims to remove a subtle syntax error so table creation does not fail during schema setup. 
- Keeping table creation and foreign key definitions correct is required for reliable DB initialization and seed application.

### Description

- Corrected the `item_effects` foreign key line in `database/database_setup.py` to read `FOREIGN KEY (effect_id) REFERENCES status_effects(effect_id) ON DELETE CASCADE`.
- This fixes missing spacing around the `REFERENCES` and `ON DELETE` clauses so the SQL statement parses correctly.
- No other schema or table order changes were made.

### Testing

- No automated tests were run for this change (`not run`).
- The file `database/database_setup.py` was updated and committed; no runtime validation was executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946c882c4f88328b606375ae658bee2)