### PR TITLE
Fix database seed ordering and make seeding idempotent

### DIFF
--- a/database/database_setup.py
+++ b/database/database_setup.py
@@ -1750,17 +1750,23 @@ def insert_key_items(cur):
 
 def insert_treasure_chests(cur):
     logger.info("Checking treasure_chests seed data…")
-    if not table_is_empty(cur, "treasure_chests"):
-        logger.info("treasure_chests already populated – skipping")
-        return
+    values = [
+        (chest_name, spawn_weight, template_id, created_at, chest_name, template_id)
+        for (_, chest_name, spawn_weight, template_id, created_at) in MERGED_TREASURE_CHESTS
+    ]
     cur.executemany(
         """
         INSERT INTO treasure_chests (chest_name, spawn_weight, template_id, created_at)
-        VALUES (%s,%s,%s,%s)
+        SELECT %s, %s, %s, %s
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM treasure_chests
+            WHERE chest_name = %s AND template_id = %s
+        )
         """,
-        [row[1:] for row in MERGED_TREASURE_CHESTS]
+        values
     )
-    logger.info("Inserted treasure_chests.")
+    logger.info("Ensured treasure_chests.")
 
 def insert_chest_def_rewards(cur):
     logger.info("Checking chest_def_rewards seed data…")
@@ -1779,31 +1785,43 @@ def insert_chest_def_rewards(cur):
 
 def insert_class_trances(cur):
     logger.info("Checking class_trances seed data…")
-    if not table_is_empty(cur, "class_trances"):
-        logger.info("class_trances already populated – skipping")
-        return
+    values = [
+        (class_id, trance_name, duration_turns, class_id, trance_name)
+        for (_, class_id, trance_name, duration_turns) in MERGED_CLASS_TRANCES
+    ]
     cur.executemany(
         """
         INSERT INTO class_trances (class_id, trance_name, duration_turns)
-        VALUES (%s,%s,%s)
+        SELECT %s, %s, %s
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM class_trances
+            WHERE class_id = %s AND trance_name = %s
+        )
         """,
-        [row[1:] for row in MERGED_CLASS_TRANCES]
+        values
     )
-    logger.info("Inserted class_trances.")
+    logger.info("Ensured class_trances.")
 
 def insert_trance_abilities(cur):
     logger.info("Checking trance_abilities seed data…")
-    if not table_is_empty(cur, "trance_abilities"):
-        logger.info("trance_abilities already populated – skipping")
-        return
+    values = [
+        (trance_id, ability_id, trance_id, ability_id)
+        for (trance_id, ability_id) in MERGED_TRANCE_ABILITIES
+    ]
     cur.executemany(
         """
         INSERT INTO trance_abilities (trance_id, ability_id)
-        VALUES (%s,%s)
+        SELECT %s, %s
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM trance_abilities
+            WHERE trance_id = %s AND ability_id = %s
+        )
         """,
-        MERGED_TRANCE_ABILITIES
+        values
     )
-    logger.info("Inserted trance_abilities.")
+    logger.info("Ensured trance_abilities.")
 
 def insert_enemies_and_abilities(cur):
     logger.info("Checking enemies seed data…")
@@ -1990,11 +2008,11 @@ def main() -> None:
                     insert_npc_vendors(cur)
                     insert_items(cur)
                     insert_key_items(cur)
-                    insert_treasure_chests(cur)
-                    insert_chest_def_rewards(cur)
                     insert_enemies_and_abilities(cur)
                     insert_eidolons(cur)
                     insert_room_templates(cur)
+                    insert_treasure_chests(cur)
+                    insert_chest_def_rewards(cur)
                     insert_crystal_templates(cur)
                     insert_enemy_drops(cur)
                     insert_enemy_resistances(cur)


### PR DESCRIPTION
### Motivation
- Room templates are referenced by treasure chests and must be created first to avoid foreign key errors during seeding. 
- Partial or repeated seed runs were producing duplicate rows or failing when only a subset of tables existed. 
- Some seed routines used `INSERT`/`INSERT IGNORE` with prior `table_is_empty` checks which made partial re-runs fragile. 
- Log messages should reflect idempotent operations so the output matches behavior.

### Description
- Reordered the seed sequence in `main()` so `insert_room_templates()` runs before `insert_treasure_chests()` and `insert_chest_def_rewards()` to satisfy foreign keys. 
- Made `insert_class_trances()`, `insert_trance_abilities()`, and `insert_treasure_chests()` idempotent by switching to parameterized `INSERT ... SELECT ... WHERE NOT EXISTS (...)` patterns and building `values` lists from `MERGED_*` constants. 
- Replaced some `INSERT IGNORE` / skip-if-empty patterns with existence-aware inserts and changed related log messages from `Inserted ...` to `Ensured ...` to reflect idempotency. 
- Kept other seed inserts (e.g. enemies) using `INSERT IGNORE` unchanged where appropriate to preserve current behavior.

### Testing
- No automated tests were run on these changes.
- The change was committed locally and validated by running the repository linter/CI was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946ceb6d49c8328a2a0ca37c3d2d3f5)