### PR TITLE
Remove ephemeral skill confirmation on ability use

### DIFF
--- a/game/battle_system.py
+++ b/game/battle_system.py
@@ -1228,25 +1228,22 @@ class BattleSystem(commands.Cog):
                         session.battle_state.get("player_effects", []) + result.status_effects
                     )
 
-            # 2) If this skill also heals immediately on use, write that to the DB now:
-            if result.type in ("heal", "set_hp"):
-                # e.g. “heal” gives you result.amount HP
-                # or “set_hp” forces to exactly result.amount
-                old_hp = self._get_player_hp(pid, session.session_id)
-                new_hp = result.amount if result.type == "set_hp" else min(
-                    old_hp + result.amount,
-                    self._get_player_max_hp(pid, session.session_id),
-                )
-                self._update_player_hp(pid, session.session_id, new_hp)
-                session.game_log.append(f"You are healed to {new_hp} HP.")
+                # 2) If this skill also heals immediately on use, write that to the DB now:
+                if result.type in ("heal", "set_hp"):
+                    # e.g. “heal” gives you result.amount HP
+                    # or “set_hp” forces to exactly result.amount
+                    old_hp = self._get_player_hp(pid, session.session_id)
+                    new_hp = result.amount if result.type == "set_hp" else min(
+                        old_hp + result.amount,
+                        self._get_player_max_hp(pid, session.session_id),
+                    )
+                    self._update_player_hp(pid, session.session_id, new_hp)
+                    session.game_log.append(f"You are healed to {new_hp} HP.")
 
-            # 3) Send the same ephemeral confirmation you already build in game_log
-            await interaction.followup.send("\n".join(session.game_log), ephemeral=True)
-
-            # 4) Finally—*after* writing to the DB— redraw the *room* (not the battle embed)
-            #    so your room embed updates with your new HP and buttons.
-            sm = self.bot.get_cog("SessionManager")
-            return await sm.refresh_current_state(interaction)
+                # 3) Finally—*after* writing to the DB— redraw the *room* (not the battle embed)
+                #    so your room embed updates with your new HP and buttons.
+                sm = self.bot.get_cog("SessionManager")
+                return await sm.refresh_current_state(interaction)
 
 
         # 5) apply any returned status effects


### PR DESCRIPTION
### Motivation
- Using abilities from the skill menu produced an unwanted ephemeral follow-up message to the user.  
- Out-of-battle self-target skills still need to persist buffs and update the room view without generating ephemeral popups.  
- Keep in-battle behavior (battle embed updates and enemy turns) unchanged.  

### Description
- Update `handle_skill_use` in `game/battle_system.py` to stop sending `interaction.followup.send(..., ephemeral=True)` for skill uses.  
- Restrict the out-of-battle logic so that persisting `result.status_effects`, applying immediate `heal`/`set_hp` writes, and refreshing the room via `SessionManager.refresh_current_state` only run when `not in_battle and target == "self"`.  
- Preserve existing game log updates and in-battle flows, including enemy turns and embed updates.  

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69474aca63f48328804acc42aa3d65ac)