### PR TITLE
Avoid ephemeral responses when updating embeds via component interactions

### DIFF
--- a/game/embed_manager.py
+++ b/game/embed_manager.py
@@ -98,9 +98,14 @@ class EmbedManager(commands.Cog):
         # don’t see “Interaction Failed” while we fetch/update messages.
         if not interaction.response.is_done():
             try:
-                # A plain defer is safe even when we later edit a different
-                # message via the webhook/message API.
-                await interaction.response.defer()
+                # For component interactions, defer_update avoids creating
+                # a separate (often ephemeral) response message.
+                if interaction.type == discord.InteractionType.component:
+                    await interaction.response.defer_update()
+                else:
+                    # A plain defer is safe even when we later edit a different
+                    # message via the webhook/message API.
+                    await interaction.response.defer()
             except Exception as e:  # pragma: no cover - defensive guard
                 logger.debug("send_or_update_embed: defer failed: %s", e)
 


### PR DESCRIPTION
### Motivation
- Component button clicks were resulting in ephemeral responses when embeds were updated, causing ephemeral battle log messages to appear in the battle system.
- The embed sender currently always calls `interaction.response.defer()`, which can create separate (often ephemeral) responses for component interactions.

### Description
- Change `game/embed_manager.py` so `send_or_update_embed` uses `interaction.response.defer_update()` when `interaction.type == discord.InteractionType.component`.
- Keep the original `interaction.response.defer()` behavior for non-component interactions to preserve existing flows.
- This adjustment prevents creating an extra ephemeral acknowledgment when updating or editing channel embeds driven by component clicks.

### Testing
- No automated tests were run for this change.
- The change is limited to `game/embed_manager.py` and only alters the interaction acknowledgement path for components.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69476c367d9c83289cbe83e1e609440d)