### PR TITLE
Show XP rewards in battle log and victory summary

### DIFF
--- a/game/battle_system.py
+++ b/game/battle_system.py
@@ -533,7 +533,7 @@ class BattleSystem(commands.Cog):
         gm = self.bot.get_cog("GameMaster")
         if gm:
             gm.append_game_log(session.session_id, f"{enemy['enemy_name']} was defeated!")
-        xp = enemy.get("xp_reward", 0)
+        xp = enemy.get("xp_reward", 0) or 0
         if xp and session:
             summoned = getattr(session, "summoned_eidolons", {}) or {}
             for eidolon_id in summoned.get(session.current_turn, set()):
@@ -547,6 +547,8 @@ class BattleSystem(commands.Cog):
             session.summoned_eidolons = summoned
         if xp and gm:
             await gm.award_experience(session.current_turn, session.session_id, xp)
+        if xp and session:
+            session.game_log.append(f"<@{session.current_turn}> gained {xp} XP.")
 
         conn = self.db_connect()
         cursor = conn.cursor(dictionary=True)
@@ -2016,9 +2018,12 @@ class BattleSystem(commands.Cog):
         if not mgr:
             return ""
         sid, pid = session.session_id, session.current_turn
+        xp = enemy.get("xp_reward", 0) or 0
         gil = enemy.get("gil_drop", 0)
         item_id, qty = enemy.get("loot_item_id"), enemy.get("loot_quantity", 0)
         lines: List[str] = []
+        if xp:
+            lines.append(f"You gained {xp} XP.")
         if gil:
             lines.append(f"You received {gil} Gil.")
 


### PR DESCRIPTION
### Motivation
- Players (notably Summoners) didn't see XP awarded when defeating enemies and eidolons weren't visibly gaining experience in the in-battle logs.
- The victory rewards summary did not include XP, making it hard to verify XP payouts.

### Description
- Normalize `xp_reward` reads to ensure a numeric value (`enemy.get("xp_reward", 0) or 0`) to avoid falsy/None issues when awarding XP. 
- After awarding player and eidolon XP, append an in-memory battle log line via `session.game_log.append(...)` so XP gains appear in the battle log.
- Include an XP line in the victory rewards generated by `award_loot` so the victory embed lists XP alongside gil and item drops.
- Changes are limited to `game/battle_system.py` and aim to surface XP rewards in both the live battle log and the victory summary.

### Testing
- No automated tests were run against these changes.
- Code was committed after the changes and inspected via the repository diff to confirm the inserted log lines and XP handling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69476e07839c8328bc72cdb944370325)