### PR TITLE
Fix indentation in `get_level_growth` to prevent import-time errors

### DIFF
--- a/utils/stat_levelup.py
+++ b/utils/stat_levelup.py
@@ -35,11 +35,11 @@ def get_level_growth(level: int) -> dict:
         conn.close()
         if row:
             # Extract only the growth multipliers.
-        growth_keys = [
-            "hp_increase", "attack_increase", "magic_increase", "defense_increase",
-            "magic_defense_increase", "accuracy_increase", "evasion_increase", "speed_increase",
-            "mp_increase",
-        ]
+            growth_keys = [
+                "hp_increase", "attack_increase", "magic_increase", "defense_increase",
+                "magic_defense_increase", "accuracy_increase", "evasion_increase",
+                "speed_increase", "mp_increase",
+            ]
             growth = {key: row.get(key, 0) for key in growth_keys}
             return growth
         else:


### PR DESCRIPTION
### Motivation
- `get_level_growth` in `utils/stat_levelup.py` had mis-indented code so `growth_keys` and `growth` were outside the `if row:` block, causing import-time failures.
- When `utils.stat_levelup` fails to import, `award_experience`'s call to `update_player_stats` raises and the level-up logic is skipped, so players do not get leveled in the DB.
- This change fixes the root cause so growth multipliers are retrieved correctly when a level row exists.

### Description
- Adjusted indentation in `get_level_growth` so `growth_keys` and `growth` are executed inside the `if row:` block in `utils/stat_levelup.py`.
- Preserved existing SQL queries and the `update_player_stats` behavior with no other functional changes.
- Logging and error handling remain unchanged.

### Testing
- No automated tests were run for this change.
- Please run the project CI or unit tests to validate the level-up flow and confirm imports succeed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69477311bd08832883c26991afbc19ef)