### PR TITLE
Replace `defer_update` with `defer` to fix interaction failures on button clicks

### DIFF
--- a/game/embed_manager.py
+++ b/game/embed_manager.py
@@ -98,10 +98,10 @@ class EmbedManager(commands.Cog):
         # don’t see “Interaction Failed” while we fetch/update messages.
         if not interaction.response.is_done():
             try:
-                # For component interactions, defer_update avoids creating
-                # a separate (often ephemeral) response message.
+                # For component interactions, defer without creating a
+                # response message. We will edit the target message directly.
                 if interaction.type == discord.InteractionType.component:
-                    await interaction.response.defer_update()
+                    await interaction.response.defer()
                 else:
                     # A plain defer is safe even when we later edit a different
                     # message via the webhook/message API.

--- a/game/game_master.py
+++ b/game/game_master.py
@@ -2736,7 +2736,7 @@ class GameMaster(commands.Cog):
 
             if cid.startswith("setup_"):
                 # e.g. “setup_4” → 4‑player session
-                await interaction.response.defer_update()
+                await interaction.response.defer()
                 parts = cid.split("_",1)
                 try:
                     slots = int(parts[1])


### PR DESCRIPTION
### Motivation
- Button clicks were causing "Interaction Failed" and terminal errors because component interactions were being acknowledged with `defer_update` which didn't match the interaction handling used elsewhere. 
- Interactions must be acknowledged before editing or sending messages to avoid race conditions when updating embeds and views.

### Description
- In `game/embed_manager.py` changed component interaction acknowledgement to `await interaction.response.defer()` (previously `defer_update`) and updated the comment to reflect editing the target message directly. 
- In `game/game_master.py` replaced `await interaction.response.defer_update()` with `await interaction.response.defer()` in the `setup_` handler used for session creation. 
- Kept the pre-edit acknowledgement behavior and per-channel locking logic intact to serialize rapid updates.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947789642508328879e7efeb73422cf)