### PR TITLE
Preserve Eidolon battles and route item/back navigation to battle embed

### DIFF
--- a/game/inventory_shop.py
+++ b/game/inventory_shop.py
@@ -205,7 +205,7 @@ class InventoryShop(commands.Cog):
             elif cid == "back_from_use":
                 mgr = self.bot.get_cog("SessionManager")
                 if mgr:
-                    await mgr.refresh_current_state(interaction)
+                    await mgr.return_to_current_view(interaction)
             # --------------- Back to room ---------------
             elif cid == "shop_back_room":
                 mgr = self.bot.get_cog("SessionManager")
@@ -510,7 +510,7 @@ class InventoryShop(commands.Cog):
 
         await interaction.followup.send(txt, ephemeral=True)
         if mgr:
-            await mgr.refresh_current_state(interaction)
+            await mgr.return_to_current_view(interaction)
 
     # --------------------------------------------------------------------- #
     # BUY / SELL BACK-END

--- a/game/session_manager.py
+++ b/game/session_manager.py
@@ -377,8 +377,10 @@ class SessionManager(commands.Cog):
 
         # ── Safety patch: if session thinks battle ongoing but room is now safe ───────
         if session.battle_state and room.get("room_type") not in ("monster", "miniboss", "boss"):
-            logger.warning("⚠️ Battle state mismatch — clearing stale battle for session %s", session.session_id)
-            session.clear_battle_state()
+            enemy = session.battle_state.get("enemy") or {}
+            if not (room.get("room_type") == "cloister" and enemy.get("role") == "eidolon"):
+                logger.warning("⚠️ Battle state mismatch — clearing stale battle for session %s", session.session_id)
+                session.clear_battle_state()
 
         # ── If still in battle, refresh battle view ───────────────────────────────────
         if session.battle_state:


### PR DESCRIPTION
### Motivation
- Using items or pressing Back during an Eidolon (cloister) fight returned players to the room view instead of the active battle embed. 
- That caused Eidolon attunement/battles to restart or be lost when the UI refreshed. 
- The intent is to keep Eidolon battles active when the player remains in the cloister and restore the battle embed after inventory actions. 

### Description
- Stop clearing `session.battle_state` for Eidolon fights in cloister rooms by skipping the stale-battle clear when `enemy.role == 'eidolon'` and the room is a `cloister` in `session_manager.py`. 
- Route inventory/back flows through `SessionManager.return_to_current_view` so the UI restores the current battle embed instead of always calling `refresh_current_state` in `inventory_shop.py`. 
- Updated the `back_from_use` interaction handler and the post-item-use refresh to call `return_to_current_view` instead of `refresh_current_state`. 

### Testing
- No automated tests were run as part of this change. 
- Manual verification is expected to confirm that using items and pressing Back during an Eidolon cloister fight returns to the battle embed and does not clear the battle state.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69478024a2488328bef833215fc07497)