### PR TITLE
Prevent empty edit when loading sessions

### DIFF
--- a/hub/hub_manager.py
+++ b/hub/hub_manager.py
@@ -246,7 +246,7 @@ class HubManager(commands.Cog):
 
             # 3) Clear the original slot picker
             return await interaction.edit_original_response(
-                content=None,
+                content="Loading your adventure…",
                 embed=None,
                 view=None
             )


### PR DESCRIPTION
### Motivation
- Selecting a saved slot triggered Discord's `HTTPException: 400 Bad Request (50006)` because the code attempted to edit a message to an empty payload.
- The issue occurs in the ephemeral load-slot flow when clearing the slot picker with `edit_original_response(content=None, embed=None, view=None)`.
- Provide a non-empty placeholder so Discord accepts the edit while the session is loading.
- Preserve the existing defer/follow-up flow and the call to `load_session` so behavior remains unchanged aside from the placeholder message.

### Description
- Modified `hub/hub_manager.py` inside the `hub_load_slot_` handler to avoid sending an empty edit response.
- Replaced the empty edit call `edit_original_response(content=None, embed=None, view=None)` with `edit_original_response(content="Loading your adventure…", embed=None, view=None)`.
- Left the `await interaction.response.defer(ephemeral=True)` and `await self.bot.get_cog("SessionManager").load_session(interaction, session_id)` calls intact.
- The change is a single-line guard to prevent Discord from rejecting the edit as an empty message.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947820511a8832897f7351d725be4f9)