### PR TITLE
Fix eidolon summon reuse and stale ability menu after turn end

### DIFF
--- a/game/game_master.py
+++ b/game/game_master.py
@@ -2341,6 +2341,11 @@ class GameMaster(commands.Cog):
         session.active_summons.pop(prev_pid, None)
         session.summon_used = getattr(session, "summon_used", {}) or {}
         session.summon_used.pop(prev_pid, None)
+        session.eidolon_ability_cooldowns = getattr(session, "eidolon_ability_cooldowns", {}) or {}
+        eidolon_cds = session.eidolon_ability_cooldowns.get(prev_pid, {})
+        for aid in list(eidolon_cds):
+            eidolon_cds[aid] = max(eidolon_cds[aid] - 1, 0)
+        session.eidolon_ability_cooldowns[prev_pid] = eidolon_cds
 
         # 2️⃣ Advance to the next alive player
         await self.advance_turn(interaction, interaction.channel.id)
@@ -2353,6 +2358,10 @@ class GameMaster(commands.Cog):
         # 4️⃣ Finally redraw that player’s view
         if sm.consume_room_refresh_intent(session):
             await sm.refresh_current_state(interaction)
+        elif session.current_enemy and session.battle_state:
+            bs = self.bot.get_cog("BattleSystem")
+            if bs:
+                await bs.update_battle_embed(interaction, session.current_turn, session.current_enemy)
 
 
     # ────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Prevent eidolon abilities from becoming permanently unusable across multiple summons by ensuring their cooldowns tick down each turn.
- Avoid showing stale ephemeral messages/buttons for an eidolon after it was recalled by refreshing the battle embed when turns rotate.

### Description
- Decrement per-player `eidolon_ability_cooldowns` for the outgoing player in `end_player_turn` so eidolon cooldowns reduce each turn.
- Clear `active_summons` and `summon_used` for the outgoing player as before and ensure `eidolon_ability_cooldowns` are stored back on the session.
- After advancing the turn, refresh the room view as before and additionally call the BattleSystem `update_battle_embed` when a battle is active to remove stale summon buttons.
- Changes are localized to `game/game_master.py` within the turn-end flow.

### Testing
- No automated tests were run against this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69478deca4b48328853c50e7de7e8d6d)