### PR TITLE
Remove incorrect BattleSystem import to fix return-to-battle view

### DIFF
--- a/game/session_manager.py
+++ b/game/session_manager.py
@@ -440,7 +440,6 @@ class SessionManager(commands.Cog):
             return
 
         if session.battle_state:
-            from game.battle.system import BattleSystem
             bs = self.bot.get_cog("BattleSystem")
             if bs:
                 await bs.update_battle_embed(


### PR DESCRIPTION
### Motivation
- Returning to the battle embed after using an item was failing due to an unnecessary local import in the return flow.
- The redundant `from game.battle.system import BattleSystem` could cause import errors or circular import issues at runtime. 
- The intent is to rely on the bot's loaded cog instance instead of re-importing the module. 

### Description
- Removed the local `from game.battle.system import BattleSystem` import inside `return_to_current_view` in `game/session_manager.py`.
- The code now consistently uses `self.bot.get_cog("BattleSystem")` to obtain the battle system instance.
- The change prevents an import-related failure that prevented `update_battle_embed` from being called.
- Modified file: `game/session_manager.py`.

### Testing
- No automated tests were run for this change.
- The change is a small import removal and should not affect other logic paths when the `BattleSystem` cog is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69478e6096008328a2084b816db22b0f)