### PR TITLE
Sync slash commands once during startup via AdventureBot.setup_hook

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -75,7 +75,21 @@ intents.members = True
 # ---------------------
 #   BOT INITIALIZATION
 # ---------------------
-bot = commands.Bot(command_prefix="/", intents=intents)
+class AdventureBot(commands.Bot):
+    async def setup_hook(self) -> None:
+        try:
+            await self.tree.sync()
+            synced_guilds = [guild.id for guild in self.guilds]
+            logger.info(
+                "✅ Slash commands synced for %s guilds: %s",
+                len(synced_guilds),
+                synced_guilds,
+            )
+        except Exception as e:
+            logger.error("❌ Failed to sync slash commands: %s", e)
+
+
+bot = AdventureBot(command_prefix="/", intents=intents)
 
 @bot.event
 async def on_ready():
@@ -83,12 +97,6 @@ async def on_ready():
     await bot.wait_until_ready()
     if not bot.application_id:
         bot.application_id = (await bot.application_info()).id
-    try:
-        await bot.tree.sync()
-        synced_guilds = [guild.id for guild in bot.guilds]
-        logger.info(f"✅ Slash commands synced for {len(synced_guilds)} guilds: {synced_guilds}")
-    except Exception as e:
-        logger.error(f"❌ Failed to sync slash commands: {e}")
     await bot.change_presence(activity=discord.Game(name="Dungeon Adventure!"))
 
 @bot.event


### PR DESCRIPTION
### Motivation
- Repeated `bot.tree.sync()` calls from `on_ready` can spam Discord’s application command endpoints and trigger rate limits leading to unstable bot behavior.  
- The code initially added a process-level flag and lock to reduce duplicate syncs, but a cleaner solution is to run the sync once per process during startup.  
- Moving the sync into a startup hook follows `discord.py` best-practices and avoids running heavy REST work in `on_ready`.  

### Description
- Add an `AdventureBot` class that subclasses `commands.Bot` and implements `async def setup_hook(self)` to run `await self.tree.sync()` once during process startup.  
- Remove the previous repeated-sync logic from `on_ready` so `on_ready` only handles readiness logging and presence via `await bot.change_presence(...)`.  
- Keep existing logging around successful syncs and failures so the number/list of synced guilds is recorded with `logger.info` and exceptions are logged with `logger.error`.  

### Testing
- No automated tests were executed for this change.  
- No CI or unit test runs were performed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947f29b0bf08328a31028b08a526e3f)