### PR TITLE
Persist player status effects to DB when battle ends

### DIFF
--- a/game/battle_system.py
+++ b/game/battle_system.py
@@ -583,12 +583,19 @@ class BattleSystem(commands.Cog):
                 session.game_state = new_room
 
         # ─── Completely tear down combat state ─────────────────────────
-        # 1) Clear out any lingering player‐side DoT/status effects
+        # 1) Persist any lingering player‐side DoT/status effects
         if session.battle_state:
+            player_effects = session.battle_state.get("player_effects", []) or []
+            SessionPlayerModel.update_status_effects(
+                session.session_id,
+                session.current_turn,
+                player_effects,
+            )
+            # 2) Clear out any lingering player/enemy effects from battle state
             session.battle_state.pop("player_effects", None)
             session.battle_state.pop("enemy_effects", None)
 
-        # 2) Call your normal clear (in case it resets other bits)
+        # 3) Call your normal clear (in case it resets other bits)
         session.clear_battle_state()
 
         # ─── Now show the “Victory!” embed ─────────────────────────────


### PR DESCRIPTION
### Motivation
- Status effects applied during combat were being removed from `session.battle_state` on victory and not persisted, causing buffs/debuffs and DoT/HoT to disappear outside of battle.
- The fix ensures out-of-combat ticking and UI lines (icons/remaining ticks) continue to work after a fight ends.

### Description
- In `game/battle_system.py` persist any `player_effects` from `session.battle_state` to the database via `SessionPlayerModel.update_status_effects` before clearing battle state.
- After persisting, clear `player_effects` and `enemy_effects` from `session.battle_state` and then call `session.clear_battle_state` to preserve other teardown behavior.
- The change keeps the previous UI/cleanup flow intact but reorders write-back so out-of-combat systems can read active effects.

### Testing
- No automated tests were run against this change.
- Manual runtime validation was implied by reproducing the issue and applying the persistence change (not an automated test run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694806cb80ec8328bf7db32f33115a6b)