### PR TITLE
Show MP cost on skill buttons when nonzero

### DIFF
--- a/game/embed_manager.py
+++ b/game/embed_manager.py
@@ -604,7 +604,10 @@ class EmbedManager(commands.Cog):
                 if duration is not None and duration_max:
                     duration_bar = create_progress_bar(int(duration), int(duration_max), length=6)
                 cd_bar = create_cooldown_bar(cur_cd, cd) if cd and cur_cd else ("[Ready]" if cd else "")
+                mp_cost = ab.get("mp_cost", 0) or 0
                 label_parts = [icon, ab["ability_name"]]
+                if mp_cost > 0:
+                    label_parts.append(f"[MP Cost: {mp_cost}]")
                 if duration_bar:
                     label_parts.append(duration_bar)
                 if cd_bar:


### PR DESCRIPTION
### Motivation
- Players should see the MP cost for abilities on the skill selection buttons so they can make informed choices before using a skill.
- Abilities that cost no MP should not display a `[MP Cost: 0]` label as that would be noisy and unhelpful.

### Description
- Updated `game/embed_manager.py` in `send_skill_menu_embed` to read `mp_cost = ab.get("mp_cost", 0) or 0` and only append `"[MP Cost: {mp_cost}]"` when `mp_cost > 0`.
- The MP cost fragment is added to the `label_parts` list alongside the ability icon and name, preserving existing duration and cooldown parts and the 80-character label truncation logic.
- Button creation and enabled/disabled state behavior remain unchanged.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69480ec064108328bd16f3a8c169e9c7)