### PR TITLE
Ignore setup_new_game in HubManager interaction handler

### DIFF
--- a/hub/hub_manager.py
+++ b/hub/hub_manager.py
@@ -275,6 +275,10 @@ class HubManager(commands.Cog):
                 view=HubView()
             )
 
+        if cid == "setup_new_game":
+            # Handled by GameMaster; avoid logging as unhandled.
+            return
+
         logger.debug(f"HubManager: unhandled custom_id='{cid}'")
 
 


### PR DESCRIPTION
### Motivation
- Prevent the hub from treating the "New Game" button as an unhandled interaction so the GameMaster can process it. 
- Avoid noisy `logger.debug` entries for `custom_id="setup_new_game"` when the button is clicked. 

### Description
- Added an early check in `HubManager.on_interaction` to `return` when `cid == "setup_new_game"` with a clarifying comment. 
- Changed file: `hub/hub_manager.py` to stop logging `setup_new_game` as unhandled so `game/game_master.py` can handle session creation. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69480e8663408328bb0b79ca20eda528)