### PR TITLE
Show MP costs in summon and trance ability menus

### DIFF
--- a/game/battle_system.py
+++ b/game/battle_system.py
@@ -970,8 +970,15 @@ class BattleSystem(commands.Cog):
 
         buttons = []
         for eid in unlocked:
+            summon_cost = eid.get("summon_mp_cost", 0) or 0
+            label_parts = [f"{eid['name']} (Lv {eid['level']})"]
+            if summon_cost > 0:
+                label_parts.append(f"[MP Cost: {summon_cost}]")
+            label = " ".join(label_parts).strip()
+            if len(label) > 80:
+                label = label[:77] + "..."
             buttons.append((
-                f"{eid['name']} (Lv {eid['level']})",
+                label,
                 discord.ButtonStyle.primary,
                 f"summon_select_{eid['eidolon_id']}",
                 0,
@@ -1022,7 +1029,15 @@ class BattleSystem(commands.Cog):
             cd_now = int(cds.get(a["ability_id"], 0))
             bar = create_cooldown_bar(cd_now, a.get("cooldown", 0), length=6)
             style = discord.ButtonStyle.secondary if cd_now > 0 else discord.ButtonStyle.primary
-            label = f"{a['ability_name']} {bar}".strip()
+            mp_cost = a.get("mp_cost", 0) or 0
+            label_parts = [a["ability_name"]]
+            if mp_cost > 0:
+                label_parts.append(f"[MP Cost: {mp_cost}]")
+            if bar:
+                label_parts.append(bar)
+            label = " ".join(label_parts).strip()
+            if len(label) > 80:
+                label = label[:77] + "..."
             buttons.append((
                 label,
                 style,
@@ -1062,6 +1077,7 @@ class BattleSystem(commands.Cog):
             SELECT ta.ability_id,
                    a.ability_name,
                    a.cooldown,
+                   a.mp_cost,
                    a.icon_url
               FROM trance_abilities ta
               JOIN abilities a USING (ability_id)
@@ -1081,7 +1097,15 @@ class BattleSystem(commands.Cog):
             cd_now = int(cds.get(a["ability_id"], 0))
             bar = create_cooldown_bar(cd_now, a["cooldown"], length=6)
             style = discord.ButtonStyle.secondary if cd_now > 0 else discord.ButtonStyle.primary
-            label = f"{a['ability_name']} {bar}".strip()
+            mp_cost = a.get("mp_cost", 0) or 0
+            label_parts = [a["ability_name"]]
+            if mp_cost > 0:
+                label_parts.append(f"[MP Cost: {mp_cost}]")
+            if bar:
+                label_parts.append(bar)
+            label = " ".join(label_parts).strip()
+            if len(label) > 80:
+                label = label[:77] + "..."
             buttons.append((label, style, f"combat_trance_{a['ability_id']}", 0, cd_now > 0))
 
         # ← Back


### PR DESCRIPTION
### Motivation
- Make MP costs visible on Eidolon summon buttons so players can see summon cost before choosing.
- Surface MP costs on Eidolon ability menus to match MP display on regular ability buttons.
- Include MP costs inside Trance ability menus because those abilities also live in the `abilities` table and have `mp_cost`.
- Keep button labels readable by truncating long labels to fit Discord button limits.

### Description
- Updated `show_summon_menu` to build summon button labels that include `[MP Cost: N]` when `summon_mp_cost` > 0 and truncate labels > 80 chars.
- Updated `show_eidolon_ability_menu` to include each ability's `mp_cost` in the button label and truncate long labels.
- Updated `display_trance_menu` SQL to select `a.mp_cost` and include the MP cost in trance ability button labels with the same truncation behavior.
- Common label construction now uses `label_parts` and joins parts (name, optional `[MP Cost: N]`, cooldown/duration bars) to form the final button label.

### Testing
- No automated tests were executed for this change.
- Runtime behavior should show MP costs in the summon, eidolon ability, and trance ability menus when `mp_cost`/`summon_mp_cost` > 0.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948161ca3f48328ad4a0e2132a5998c)