### PR TITLE
Gate out-of-battle summoning by eidolon support abilities

### DIFF
--- a/game/battle_system.py
+++ b/game/battle_system.py
@@ -964,6 +964,14 @@ class BattleSystem(commands.Cog):
         if not unlocked:
             return await interaction.response.send_message("❌ You have not unlocked any Eidolons yet.", ephemeral=True)
 
+        if not session.battle_state and not SessionPlayerModel.has_out_of_battle_eidolon_support(
+            session.session_id, pid
+        ):
+            return await interaction.response.send_message(
+                "❌ None of your Eidolons can support you outside of battle.",
+                ephemeral=True,
+            )
+
         session.summon_used = getattr(session, "summon_used", {}) or {}
         if session.summon_used.get(pid):
             return await interaction.response.send_message("❌ You can only summon once per turn.", ephemeral=True)

--- a/game/game_master.py
+++ b/game/game_master.py
@@ -1360,7 +1360,14 @@ class GameMaster(commands.Cog):
         has_key = _player_has_key(session.session_id, session.current_turn)
 
         session.summon_used = getattr(session, "summon_used", {}) or {}
-        can_summon = class_name == "Summoner" and bool(unlocked_eidolons) and not session.summon_used.get(session.current_turn)
+        can_summon = (
+            class_name == "Summoner"
+            and bool(unlocked_eidolons)
+            and not session.summon_used.get(session.current_turn)
+            and SessionPlayerModel.has_out_of_battle_eidolon_support(
+                session.session_id, session.current_turn
+            )
+        )
         buttons = em.get_main_menu_buttons(
             directions=exits,
             include_shop=(room.get("vendor_id") is not None),


### PR DESCRIPTION
### Motivation
- Prevent the Summon action from appearing outside of combat unless the player has an Eidolon that can actually support the summoner out of battle.  
- Keep in-battle summoning behavior unchanged so summoned Eidolons and their abilities remain available during combat.  
- Reuse existing ability-target semantics (self/ally/any) to determine which Eidolon abilities qualify as out-of-battle support.  

### Description
- Add `SessionPlayerModel.has_out_of_battle_eidolon_support(session_id, player_id)` which checks unlocked Eidolon abilities with `target_type IN ('self','ally','any')`.  
- Require `has_out_of_battle_eidolon_support` when computing `can_summon` for the main (out-of-battle) menu in `GameMaster`.  
- Block opening the summon menu in `BattleSystem.show_summon_menu` when not in battle and no support-capable Eidolons exist, returning an explanatory ephemeral message.  

### Testing
- No automated tests were executed for this change.  
- No additional automated verification (lint/test tooling) was run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69481a9ded20832896fcbb6d476d050b)