### PR TITLE
Remove trap rooms and add entrance marker to minimap

### DIFF
--- a/game/dungeon_generator.py
+++ b/game/dungeon_generator.py
@@ -519,6 +519,7 @@ class DungeonGenerator(commands.Cog):
                 rt for rt, cap in remaining.items()
                 if cap > 0
                 and rt not in ("staircase_up","staircase_down")
+                and rt != "trap"
                 and not (exclude_locked and rt == "locked")
                 and not (exclude_item and rt == "item")
                 and not (exclude_special and rt in self.SPECIAL_ROOM_TYPES)
@@ -527,7 +528,7 @@ class DungeonGenerator(commands.Cog):
                 return "monster" if random.random() < enemy_chance else "safe"
             choice_ = random.choices(avail, weights=[weights[a] for a in avail])[0]
             remaining[choice_] -= 1
-            if choice_ in ("trap","illusion") and not self.fetch_random_template(choice_):
+            if choice_ == "illusion" and not self.fetch_random_template(choice_):
                 return "monster" if random.random() < enemy_chance else "safe"
             return choice_
 

--- a/game/embed_manager.py
+++ b/game/embed_manager.py
@@ -478,8 +478,8 @@ class EmbedManager(commands.Cog):
             name="__**Legend**__",
             value=(
                 "**🤺 You**  **🟨 Visited**  **🟩 Safe**  **🟥 Monster**  **⬛ Unknown**\n"
-                "**🟦 Item**  **👤 Quest**  **🔼 Up**  **🔽 Down**\n"
-                "**🟧 Trap**  **🔒 Locked**  **🟪 Shop**  **🔮 Illusion**\n"
+                "**⬜ Entrance**  **🟦 Item**  **👤 Quest**  **🔼 Up**  **🔽 Down**\n"
+                "**🔒 Locked**  **🟪 Shop**  **🔮 Illusion**\n"
                 "**💀 Boss**  **🚪 Exit**  **⚰️ Fallen Player**"
             ),
             inline=False,

--- a/game/game_master.py
+++ b/game/game_master.py
@@ -1754,11 +1754,7 @@ class GameMaster(commands.Cog):
         if not landed:
             return await interaction.followup.send("❌ Room data missing.", ephemeral=True)
 
-        # ── 7. special cases: trap / monster ─────────────────────────
-        if landed["room_type"] == "trap":
-            await self.trigger_trap(interaction, landed)
-            return
-
+        # ── 7. special cases: monster ─────────────────────────
         if landed["room_type"] in ("boss", "miniboss", "monster"):
             bs = self.bot.get_cog("BattleSystem")
             if bs:
@@ -1786,26 +1782,6 @@ class GameMaster(commands.Cog):
         await self.update_room_view(interaction, landed, nx, ny)
         await self.end_player_turn(interaction)
         
-
-    # ──────────────────────────────────────────────────────────
-    #  Trap dispatcher
-    # ──────────────────────────────────────────────────────────
-    async def trigger_trap(self,
-                           interaction: discord.Interaction,
-                           room: dict[str, Any]) -> None:
-        """
-        For now, trap rooms behave exactly like safe rooms:
-        just redraw the current room.  Future trap effects (e.g.,
-        periodic HP loss over several turns) go here.
-        """
-        # TODO: apply trap effects (e.g. debuff, %HP drain per turn)
-        await self.update_room_view(
-            interaction,
-            room,
-            room["coord_x"],
-            room["coord_y"],
-        )
-        await self.end_player_turn(interaction)
 
     async def handle_quit_game(self, interaction: Interaction) -> None:
         sm: SessionManager = self.bot.get_cog("SessionManager")

--- a/utils/ui_helpers.py
+++ b/utils/ui_helpers.py
@@ -62,7 +62,7 @@ def get_emoji_for_room_type(room_type: str) -> str:
     """
     mapping = {
         "safe":           "🟩",
-        "entrance":       "🟩",
+        "entrance":       "⬜",
         "monster":        "🟥",
         "boss":           "💀",
         "illusion":       "🔮",
@@ -74,7 +74,6 @@ def get_emoji_for_room_type(room_type: str) -> str:
         "locked":         "🔒",
         "staircase_up":   "🔼",
         "staircase_down": "🔽",
-        "trap":           "🟧",
         "cloister":       "🧿",
     }
     if not room_type:


### PR DESCRIPTION
### Motivation
- Trap rooms and their effects will no longer be developed, so trap handling and generation should be removed from game logic.
- The minimap should still indicate the starting/entrance tile so players can orient themselves.
- Preventing trap generation keeps dungeon generation consistent with the new design direction.

### Description
- Replaced the entrance room emoji in `get_emoji_for_room_type` (in `utils/ui_helpers.py`) to use a white square (`⬜`).
- Removed the `trigger_trap` dispatcher and the trap branch from the movement flow in `game/game_master.py` so traps are no longer handled on move.
- Excluded `"trap"` from selectable room types in `game/dungeon_generator.py` and adjusted the illusion-template check accordingly.
- Updated the minimap legend in `game/embed_manager.py` to add an `⬜ Entrance` entry and removed the trap entry from the legend.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948238d8c388328a29ce9eb6030a3cc)