### PR TITLE
Make hub tutorial & high scores ephemeral; add sortable high-scores view and schema fields

### DIFF
--- a/database/database_setup.py
+++ b/database/database_setup.py
@@ -1474,8 +1474,11 @@ TABLES = {
             guild_id         BIGINT NOT NULL,
             player_level     INT DEFAULT 1,
             player_class     VARCHAR(50),
+            difficulty       VARCHAR(50),
             gil              INT DEFAULT 0,
             enemies_defeated INT DEFAULT 0,
+            rooms_visited    INT DEFAULT 0,
+            items_found      INT DEFAULT 0,
             play_time        INT DEFAULT 0,
             completed_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )


### PR DESCRIPTION
### Motivation
- Present tutorial pages and high scores as user‑scoped ephemeral embeds instead of editing the global main hub embed.  
- Provide a per-user sortable high-scores UI with clear sort option descriptions and a top‑20 formatted list.  
- Capture more session metrics (rooms, items, difficulty) in the `high_scores` table so the UI can sort and display richer data.  
- Avoid unsafe or hard-coded ordering by validating sort keys and enforcing a deterministic fallback.

### Description
- Added new columns to the high score schema: `difficulty`, `rooms_visited`, and `items_found` in `database/database_setup.py`.  
- Reworked `HubModel.get_high_scores` in `models/hub_model.py` to accept `guild_id`, `sort_key`, and `limit`, validate available columns, and build a safe `ORDER BY` query with a fallback.  
- Implemented high score sort metadata, time formatting, and `get_high_scores_embed_for_sort` in `hub/hub_embed.py` to render a descriptive ephemeral embed and a formatted Top‑20 session list.  
- Updated `hub/hub_manager.py` to send the tutorial and high scores as ephemeral messages, and added `HighScoreSortSelect` and `HighScoresView` to provide a dropdown sorter and close action for the ephemeral high score view.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694827b45b3883288649b586814ff0a8)