### PR TITLE
Add initiative-based battle turn scheduling with haste/slow modifiers

### DIFF
--- a/database/database_setup.py
+++ b/database/database_setup.py
@@ -1307,6 +1307,7 @@ TABLES = {
             magic_defense INT DEFAULT 5,
             accuracy INT DEFAULT 95,
             evasion INT DEFAULT 5,
+            speed INT DEFAULT 10,
             difficulty VARCHAR(50),
             abilities JSON,
             image_url VARCHAR(255),
@@ -2228,6 +2229,8 @@ def main() -> None:
                     tables_to_seed.add("rooms")
                 if ensure_column(cur, "rooms", "attune_level", "INT NULL"):
                     tables_to_seed.add("rooms")
+                if ensure_column(cur, "enemies", "speed", "INT DEFAULT 10"):
+                    tables_to_seed.add("enemies")
 
                 # ── seed data (order matters) ──────────────────────────────────
                 if "difficulties" in tables_to_seed:


### PR DESCRIPTION
### Motivation
- Implement Final Fantasy–style turn-delay / initiative accumulation so `Haste`/`Slow` affect turn frequency without adding a full ATB system. 
- Ensure speed-based advantages don’t grant accidental instant extra turns at battle start. 
- Integrate haste/slow as status-driven multipliers so existing abilities and status infrastructure can drive the effect. 
- Tick end-of-round logic (Trance / temporary abilities / summon state) consistently when initiative advances.

### Description
- Added initiative gauge support stored in `session.battle_state['initiative']` and helpers: `_get_initiative_state`, `_get_battle_speed`, `_advance_initiative`, `_advance_battle_turn`, and `_finalize_battle_round` in `game/battle_system.py`.
- `Haste`/`Slow` are applied as simple multipliers inside `_get_battle_speed` (currently `1.5x` for Haste, `0.5x` for Slow) and read from `session.battle_state` effect lists so existing status application works unchanged.
- Replaced direct enemy scheduling calls with the new `_advance_battle_turn` flow so initiative accumulation decides the next actor and avoids free initial extra turns; updated multiple callsites in `game/battle_system.py` to use the new flow.
- Added `speed` to enemy selects and added a migration to create an `enemies.speed` column via `database/database_setup.py` (`ensure_column(cur, "enemies", "speed", "INT DEFAULT 10")`).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694826c0a71083289d6aeb1edd630ad3)