### PR TITLE
Scale enemies to party level (include speed & conservative XP scaling)

### DIFF
--- a/game/battle_system.py
+++ b/game/battle_system.py
@@ -934,7 +934,11 @@ class BattleSystem(commands.Cog):
         conn = self.db_connect()
         cursor = conn.cursor(dictionary=True)
         cursor.execute(
-            "SELECT hp, max_hp, mp, max_mp, defense, attack_power FROM players WHERE player_id = %s AND session_id = %s",
+            """
+            SELECT hp, max_hp, mp, max_mp, defense, attack_power, level
+            FROM players
+            WHERE player_id = %s AND session_id = %s
+            """,
             (player_id, session.session_id),
         )
         player = cursor.fetchone()
@@ -955,7 +959,11 @@ class BattleSystem(commands.Cog):
         val = f"❤️ HP: {create_health_bar(enemy['hp'], enemy['max_hp'])}"
         if enemy_line:
             val += f" {enemy_line}"
-        eb.add_field(name=f"Enemy: {enemy['enemy_name']}", value=val, inline=False)
+        enemy_level = enemy.get("level")
+        enemy_label = f"Enemy: {enemy['enemy_name']}"
+        if enemy_level:
+            enemy_label += f" (Lv {enemy_level})"
+        eb.add_field(name=enemy_label, value=val, inline=False)
 
         # show player HP + effects
         player_line = format_status_effects(session.battle_state["player_effects"])
@@ -965,7 +973,11 @@ class BattleSystem(commands.Cog):
         if player_line:
             stats_text += f" {player_line}"
         stats_text += f"\n⚔️ ATK: {player['attack_power']}\n🛡️ DEF: {player['defense']}"
-        eb.add_field(name="Your Stats", value=stats_text, inline=False)
+        player_level = player.get("level")
+        player_label = "Your Stats"
+        if player_level:
+            player_label += f" (Lv {player_level})"
+        eb.add_field(name=player_label, value=stats_text, inline=False)
 
         eb.add_field(name="Battle Log",
                      value="\n".join(session.game_log[-5:]) or "No actions recorded.",
@@ -1028,7 +1040,11 @@ class BattleSystem(commands.Cog):
         conn = self.db_connect()
         cursor = conn.cursor(dictionary=True)
         cursor.execute(
-            "SELECT hp, max_hp, mp, max_mp, defense, attack_power FROM players WHERE player_id = %s AND session_id = %s",
+            """
+            SELECT hp, max_hp, mp, max_mp, defense, attack_power, level
+            FROM players
+            WHERE player_id = %s AND session_id = %s
+            """,
             (player_id, session.session_id),
         )
         player = cursor.fetchone()
@@ -1047,7 +1063,11 @@ class BattleSystem(commands.Cog):
         val = f"❤️ HP: {create_health_bar(enemy['hp'], enemy['max_hp'])}"
         if enemy_line:
             val += f" {enemy_line}"
-        eb.add_field(name=f"Enemy: {enemy['enemy_name']}", value=val, inline=False)
+        enemy_level = enemy.get("level")
+        enemy_label = f"Enemy: {enemy['enemy_name']}"
+        if enemy_level:
+            enemy_label += f" (Lv {enemy_level})"
+        eb.add_field(name=enemy_label, value=val, inline=False)
 
         player_line = format_status_effects(session.battle_state.get("player_effects", []))
         stats_text = f"❤️ HP: {create_health_bar(player['hp'], player['max_hp'])}"
@@ -1059,7 +1079,11 @@ class BattleSystem(commands.Cog):
             f"\n⚔️ ATK: {player['attack_power']}\n"
             f"🛡️ DEF: {player['defense']}"
         )
-        eb.add_field(name="Your Stats", value=stats_text, inline=False)
+        player_level = player.get("level")
+        player_label = "Your Stats"
+        if player_level:
+            player_label += f" (Lv {player_level})"
+        eb.add_field(name=player_label, value=stats_text, inline=False)
 
         eb.add_field(name="Battle Log",
                      value="\n".join(session.game_log[-5:]) or "No actions recorded.",

--- a/game/game_master.py
+++ b/game/game_master.py
@@ -1200,7 +1200,11 @@ class GameMaster(commands.Cog):
         if rtype in ("monster","miniboss","boss") and room.get("default_enemy_id"):
             bs = self.bot.get_cog("BattleSystem")
             if bs:
-                enemy = await bs.get_enemy_by_id(room["default_enemy_id"])
+                enemy = await bs.get_enemy_by_id(
+                    room["default_enemy_id"],
+                    session=session,
+                    floor_id=room.get("floor_id"),
+                )
                 if enemy:
                     session.battle_state = {"enemy": enemy}
                     self.append_game_log(session.session_id, f"Encountered **{enemy['enemy_name']}**!")
@@ -1622,7 +1626,11 @@ class GameMaster(commands.Cog):
             if bs:
                 if rtype == "boss" and new_room.get("default_enemy_id"):
                     # boss rooms use their fixed enemy
-                    enemy = await bs.get_enemy_by_id(new_room["default_enemy_id"])
+                    enemy = await bs.get_enemy_by_id(
+                        new_room["default_enemy_id"],
+                        session=session,
+                        floor_id=new_room.get("floor_id"),
+                    )
                 else:
                     # miniboss & normal monster pick one dynamically
                     enemy = await bs.get_enemy_for_room(
@@ -1768,7 +1776,11 @@ class GameMaster(commands.Cog):
             if bs:
                 default_id = landed.get("default_enemy_id")
                 if landed["room_type"] == "boss" and default_id:
-                    enemy = await bs.get_enemy_by_id(default_id)
+                    enemy = await bs.get_enemy_by_id(
+                        default_id,
+                        session=session,
+                        floor_id=new_floor,
+                    )
                 else:
                     enemy = await bs.get_enemy_for_room(session, new_floor, nx, ny)
 
@@ -2462,7 +2474,11 @@ class GameMaster(commands.Cog):
         bs = self.bot.get_cog("BattleSystem")
         if not bs:
             return await interaction.response.send_message("❌ BattleSystem offline.", ephemeral=True)
-        enemy = await bs.get_enemy_by_id(eidolon["enemy_id"])
+        enemy = await bs.get_enemy_by_id(
+            eidolon["enemy_id"],
+            session=session,
+            floor_id=player.get("current_floor_id"),
+        )
         if not enemy:
             return await interaction.response.send_message("❌ Eidolon battle data missing.", ephemeral=True)
 


### PR DESCRIPTION
### Motivation
- Enemy stats (including `speed`) were static in the `enemies` table which caused initiative drift as players levelled up. 
- Enemies need to track the party so encounters remain challenging and fair while preserving database difficulty tuning. 
- XP rewards should be adjusted minimally so rewards remain consistent with enemy templates rather than explode by level. 

### Description
- Added party/floor/difficulty based enemy target level calculation via `_get_enemy_target_level` and `_get_party_level` in `game/battle_system.py`. 
- Implemented stat scaling (`_scale_enemy_stats`) that applies the existing level growth multipliers (including `speed`) and attaches a computed `level` to the enemy dict. 
- Applied conservative reward scaling (`_scale_enemy_rewards`) that nudges `xp_reward` within a tight clamp based on level delta, and exposed `_apply_enemy_level_scaling` which is invoked from `get_enemy_for_room` and `get_enemy_by_id`. 
- Wired session and `floor_id` context through calls to `get_enemy_by_id` in `game/game_master.py` so fixed/boss/eidolon lookups are scaled at spawn. 

### Testing
- No automated tests were run on this change. 
- The patch was applied and committed modifying `game/battle_system.py` and `game/game_master.py` and basic code navigation commands were used to validate hook locations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694835ca32788328a1e51f8eb6ca09da)