### PR TITLE
Allow eidolon summoning each turn

### DIFF
--- a/game/battle_system.py
+++ b/game/battle_system.py
@@ -433,6 +433,9 @@ class BattleSystem(commands.Cog):
             return
         if acting_side == "enemy":
             self._finalize_battle_round(session)
+        else:
+            session.summon_used = getattr(session, "summon_used", {}) or {}
+            session.summon_used.pop(session.current_turn, None)
         await self.update_battle_embed(interaction, session.current_turn, enemy)
     # --------------------------------------------------------------------- #
     #                     Room / Template utilities                         #
@@ -903,6 +906,8 @@ class BattleSystem(commands.Cog):
             "enemy_effects": [],
             "initiative": {"player_gauge": 0, "enemy_gauge": 0, "threshold": 100},
         }
+        session.summon_used = getattr(session, "summon_used", {}) or {}
+        session.summon_used.pop(player_id, None)
         session.victory_pending = False
         session.victory_embed_sent = False
         session.last_victory_enemy = None


### PR DESCRIPTION
### Motivation
- Summoners were only able to summon an Eidolon once and could not resummon on subsequent turns even if they had MP, so summoning should be allowed each player turn when MP permits. 
- Resetting the per-player summon-used flag at the start of battle and when a new player turn begins ensures the summon button can reappear appropriately. 

### Description
- Reset `session.summon_used` for the active player in `_advance_battle_turn` so the flag is cleared when control returns to a player (added `session.summon_used.pop(session.current_turn, None)`).
- Initialize and clear `session.summon_used` for `player_id` in `start_battle` so summoners can summon at battle start (added `session.summon_used = getattr(session, "summon_used", {}) or {}` and a `pop` call).
- Changes were made in `game/battle_system.py`, using `getattr(session, "summon_used", {}) or {}` and `pop(...)` to safely clear per-player summon usage.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69483ab381208328bde125643f597c44)