### PR TITLE
Cap normal enemy level scaling to party level

### DIFF
--- a/game/battle_system.py
+++ b/game/battle_system.py
@@ -324,6 +324,8 @@ class BattleSystem(commands.Cog):
         if not session or not enemy:
             return enemy
         target_level, party_level = self._get_enemy_target_level(session, floor_id, difficulty)
+        if enemy.get("role") not in ("boss", "miniboss"):
+            target_level = min(target_level, party_level)
         stats = self._scale_enemy_stats(enemy, target_level)
         enemy.update(stats)
         enemy["level"] = target_level


### PR DESCRIPTION
### Motivation
- Prevent regular enemies from becoming higher level than the party due to random level jitter which can produce unfair double turns.  
- Ensure minibosses and bosses retain their existing scaling behavior and are not affected by the cap.  
- Keep rewards and stat-scaling consistent while avoiding scenarios where low-level players face overleveled normal mobs.  

### Description
- Added a cap in `game/battle_system.py` inside `_apply_enemy_level_scaling` that sets `target_level = min(target_level, party_level)` for enemies whose `role` is not `"boss"` or `"miniboss"`.  
- This change only affects normal enemies and leaves miniboss/boss scaling and reward logic intact.  
- The rest of the scaling pipeline (`_scale_enemy_stats` and `_scale_enemy_rewards`) remains unchanged and continues to use the computed `target_level`.  

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949e982da288328b45518130619361b)