### PR TITLE
Simplify authoring pages to wizard flows

### DIFF
--- a/adventure-tools/src/components/Layout.tsx
+++ b/adventure-tools/src/components/Layout.tsx
@@ -13,10 +13,18 @@ const navItems = [
   "Vendors"
 ];
 
-export function Layout({ children }: { children: React.ReactNode }) {
+export function Layout({
+  children,
+  active,
+  onNavChange
+}: {
+  children: React.ReactNode;
+  active: string;
+  onNavChange: (item: string) => void;
+}) {
   return (
     <div className="min-h-screen flex text-slate-100">
-      <Sidebar items={navItems} active="Enemies" />
+      <Sidebar items={navItems} active={active} onSelect={onNavChange} />
       <div className="flex-1 flex flex-col">
         <header className="px-8 py-6 border-b border-white/10 bg-night-850/70 backdrop-blur">
           <div className="flex items-center justify-between">

--- a/adventure-tools/src/components/Sidebar.tsx
+++ b/adventure-tools/src/components/Sidebar.tsx
@@ -1,6 +1,14 @@
 import clsx from "clsx";
 
-export function Sidebar({ items, active }: { items: string[]; active: string }) {
+export function Sidebar({
+  items,
+  active,
+  onSelect
+}: {
+  items: string[];
+  active: string;
+  onSelect: (item: string) => void;
+}) {
   return (
     <aside className="w-72 border-r border-white/10 bg-night-850/80 backdrop-blur-xl px-6 py-8 flex flex-col">
       <div className="glass-panel rounded-2xl p-4">
@@ -15,6 +23,7 @@ export function Sidebar({ items, active }: { items: string[]; active: string }) 
           <button
             key={item}
             type="button"
+            onClick={() => onSelect(item)}
             className={clsx(
               "w-full flex items-center justify-between px-4 py-3 rounded-xl text-sm transition",
               item === active

--- a/adventure-tools/src/pages/AbilitiesPage.tsx
+++ b/adventure-tools/src/pages/AbilitiesPage.tsx
@@ -1,18 +1,18 @@
-export function EnemiesPage() {
+export function AbilitiesPage() {
   return (
     <div className="space-y-8">
       <section className="glass-panel rounded-3xl p-6">
         <div className="flex items-center justify-between">
           <div>
             <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Content Zone</p>
-            <h2 className="text-3xl font-display">Enemy Authoring</h2>
+            <h2 className="text-3xl font-display">Ability Authoring</h2>
             <p className="mt-2 text-sm text-slate-300 max-w-2xl">
-              Create and revise enemy content with the wizard flows below.
+              Create and adjust ability records through the authoring wizards.
             </p>
           </div>
           <div className="text-right text-xs text-slate-400">
             <p>Database</p>
-            <p className="text-aurora-cyan">adventure.enemies</p>
+            <p className="text-aurora-cyan">adventure.abilities</p>
           </div>
         </div>
       </section>
@@ -20,36 +20,36 @@ export function EnemiesPage() {
       <section className="grid lg:grid-cols-2 gap-6">
         <div className="glass-panel rounded-3xl p-6">
           <div className="flex items-center justify-between">
-            <h3 className="text-xl font-display">Enemy Creation Flow</h3>
+            <h3 className="text-xl font-display">Ability Creation Flow</h3>
             <span className="text-xs text-aurora-lime">Wizard Draft</span>
           </div>
           <ol className="mt-6 grid gap-4 text-sm text-slate-300">
             <li className="flex gap-3">
               <span className="text-aurora-cyan font-semibold">01</span>
               <div>
-                <p className="text-white">Base Identity</p>
-                <p>Name, role, lore description, images, difficulty tier.</p>
+                <p className="text-white">Identity</p>
+                <p>Name, icon, description, and targeting rules.</p>
               </div>
             </li>
             <li className="flex gap-3">
               <span className="text-aurora-violet font-semibold">02</span>
               <div>
-                <p className="text-white">Stat Blueprint</p>
-                <p>HP/MP, attack/magic, defenses, accuracy, evasion, speed/ATB.</p>
+                <p className="text-white">Effect Builder</p>
+                <p>Damage/heal formulas, status payload, scaling stat, and element link.</p>
               </div>
             </li>
             <li className="flex gap-3">
               <span className="text-aurora-magenta font-semibold">03</span>
               <div>
-                <p className="text-white">Ability Rotation</p>
-                <p>Assign abilities, weights, scaling stats, healing thresholds.</p>
+                <p className="text-white">Cost & Cooldown</p>
+                <p>MP cost, cooldown turns, and special effect triggers.</p>
               </div>
             </li>
             <li className="flex gap-3">
               <span className="text-aurora-amber font-semibold">04</span>
               <div>
-                <p className="text-white">Resistances & Drops</p>
-                <p>Element relations, loot table, gil/xp reward defaults.</p>
+                <p className="text-white">Distribution</p>
+                <p>Assign to classes, enemies, eidolons, or trance states.</p>
               </div>
             </li>
           </ol>
@@ -57,7 +57,7 @@ export function EnemiesPage() {
 
         <div className="glass-panel rounded-3xl p-6">
           <div className="flex items-center justify-between">
-            <h3 className="text-xl font-display">Enemy Update Flow</h3>
+            <h3 className="text-xl font-display">Ability Update Flow</h3>
             <span className="text-xs text-aurora-lime">Wizard Draft</span>
           </div>
           <ol className="mt-6 grid gap-4 text-sm text-slate-300">
@@ -65,28 +65,28 @@ export function EnemiesPage() {
               <span className="text-aurora-cyan font-semibold">01</span>
               <div>
                 <p className="text-white">Select Target</p>
-                <p>Search by name, role, or internal ID to load a record.</p>
+                <p>Search by name or ability ID to load the record.</p>
               </div>
             </li>
             <li className="flex gap-2">
               <span className="text-aurora-violet font-semibold">02</span>
               <div>
-                <p className="text-white">Patch Stats</p>
-                <p>Adjust HP/MP, offense/defense, speed, and reward outputs.</p>
+                <p className="text-white">Patch Core Data</p>
+                <p>Update effects, costs, cooldowns, and scaling stats.</p>
               </div>
             </li>
             <li className="flex gap-2">
               <span className="text-aurora-magenta font-semibold">03</span>
               <div>
-                <p className="text-white">Revise Behaviors</p>
-                <p>Update ability weights, resistances, and drop tables.</p>
+                <p className="text-white">Re-assign</p>
+                <p>Adjust class, enemy, or eidolon allocations.</p>
               </div>
             </li>
             <li className="flex gap-2">
               <span className="text-aurora-amber font-semibold">04</span>
               <div>
                 <p className="text-white">Publish</p>
-                <p>Review deltas and push updates to the content table.</p>
+                <p>Review the diff and save the updated ability.</p>
               </div>
             </li>
           </ol>

--- a/adventure-tools/src/pages/App.tsx
+++ b/adventure-tools/src/pages/App.tsx
@@ -1,10 +1,29 @@
+import { useMemo, useState } from "react";
 import { Layout } from "../components/Layout";
+import { AbilitiesPage } from "./AbilitiesPage";
+import { ClassesPage } from "./ClassesPage";
 import { EnemiesPage } from "./EnemiesPage";
+import { ItemsPage } from "./ItemsPage";
 
 export function App() {
+  const [active, setActive] = useState("Enemies");
+  const content = useMemo(() => {
+    switch (active) {
+      case "Items":
+        return <ItemsPage />;
+      case "Classes":
+        return <ClassesPage />;
+      case "Abilities":
+        return <AbilitiesPage />;
+      case "Enemies":
+      default:
+        return <EnemiesPage />;
+    }
+  }, [active]);
+
   return (
-    <Layout>
-      <EnemiesPage />
+    <Layout active={active} onNavChange={setActive}>
+      {content}
     </Layout>
   );
 }

--- a/adventure-tools/src/pages/ClassesPage.tsx
+++ b/adventure-tools/src/pages/ClassesPage.tsx
@@ -1,18 +1,18 @@
-export function EnemiesPage() {
+export function ClassesPage() {
   return (
     <div className="space-y-8">
       <section className="glass-panel rounded-3xl p-6">
         <div className="flex items-center justify-between">
           <div>
             <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Content Zone</p>
-            <h2 className="text-3xl font-display">Enemy Authoring</h2>
+            <h2 className="text-3xl font-display">Class Authoring</h2>
             <p className="mt-2 text-sm text-slate-300 max-w-2xl">
-              Create and revise enemy content with the wizard flows below.
+              Create and update class records through the wizard flows below.
             </p>
           </div>
           <div className="text-right text-xs text-slate-400">
             <p>Database</p>
-            <p className="text-aurora-cyan">adventure.enemies</p>
+            <p className="text-aurora-cyan">adventure.classes</p>
           </div>
         </div>
       </section>
@@ -20,36 +20,36 @@ export function EnemiesPage() {
       <section className="grid lg:grid-cols-2 gap-6">
         <div className="glass-panel rounded-3xl p-6">
           <div className="flex items-center justify-between">
-            <h3 className="text-xl font-display">Enemy Creation Flow</h3>
+            <h3 className="text-xl font-display">Class Creation Flow</h3>
             <span className="text-xs text-aurora-lime">Wizard Draft</span>
           </div>
           <ol className="mt-6 grid gap-4 text-sm text-slate-300">
             <li className="flex gap-3">
               <span className="text-aurora-cyan font-semibold">01</span>
               <div>
-                <p className="text-white">Base Identity</p>
-                <p>Name, role, lore description, images, difficulty tier.</p>
+                <p className="text-white">Identity & Fantasy</p>
+                <p>Name, lore, visual identity, and role archetype.</p>
               </div>
             </li>
             <li className="flex gap-3">
               <span className="text-aurora-violet font-semibold">02</span>
               <div>
-                <p className="text-white">Stat Blueprint</p>
-                <p>HP/MP, attack/magic, defenses, accuracy, evasion, speed/ATB.</p>
+                <p className="text-white">Base Stats</p>
+                <p>HP/MP baselines, offense/defense, accuracy, and speed.</p>
               </div>
             </li>
             <li className="flex gap-3">
               <span className="text-aurora-magenta font-semibold">03</span>
               <div>
-                <p className="text-white">Ability Rotation</p>
-                <p>Assign abilities, weights, scaling stats, healing thresholds.</p>
+                <p className="text-white">Ability Progression</p>
+                <p>Unlock levels, temporary abilities, and milestone rewards.</p>
               </div>
             </li>
             <li className="flex gap-3">
               <span className="text-aurora-amber font-semibold">04</span>
               <div>
-                <p className="text-white">Resistances & Drops</p>
-                <p>Element relations, loot table, gil/xp reward defaults.</p>
+                <p className="text-white">Trance Variants</p>
+                <p>Trance duration, ability swaps, and visual overrides.</p>
               </div>
             </li>
           </ol>
@@ -57,7 +57,7 @@ export function EnemiesPage() {
 
         <div className="glass-panel rounded-3xl p-6">
           <div className="flex items-center justify-between">
-            <h3 className="text-xl font-display">Enemy Update Flow</h3>
+            <h3 className="text-xl font-display">Class Update Flow</h3>
             <span className="text-xs text-aurora-lime">Wizard Draft</span>
           </div>
           <ol className="mt-6 grid gap-4 text-sm text-slate-300">
@@ -65,28 +65,28 @@ export function EnemiesPage() {
               <span className="text-aurora-cyan font-semibold">01</span>
               <div>
                 <p className="text-white">Select Target</p>
-                <p>Search by name, role, or internal ID to load a record.</p>
+                <p>Search class name to load the current profile.</p>
               </div>
             </li>
             <li className="flex gap-2">
               <span className="text-aurora-violet font-semibold">02</span>
               <div>
                 <p className="text-white">Patch Stats</p>
-                <p>Adjust HP/MP, offense/defense, speed, and reward outputs.</p>
+                <p>Adjust baselines for HP/MP, offense/defense, and speed.</p>
               </div>
             </li>
             <li className="flex gap-2">
               <span className="text-aurora-magenta font-semibold">03</span>
               <div>
-                <p className="text-white">Revise Behaviors</p>
-                <p>Update ability weights, resistances, and drop tables.</p>
+                <p className="text-white">Update Progression</p>
+                <p>Modify unlocks, temp skills, and trance configuration.</p>
               </div>
             </li>
             <li className="flex gap-2">
               <span className="text-aurora-amber font-semibold">04</span>
               <div>
                 <p className="text-white">Publish</p>
-                <p>Review deltas and push updates to the content table.</p>
+                <p>Review changes and save the updated class.</p>
               </div>
             </li>
           </ol>

--- a/adventure-tools/src/pages/ItemsPage.tsx
+++ b/adventure-tools/src/pages/ItemsPage.tsx
@@ -1,18 +1,18 @@
-export function EnemiesPage() {
+export function ItemsPage() {
   return (
     <div className="space-y-8">
       <section className="glass-panel rounded-3xl p-6">
         <div className="flex items-center justify-between">
           <div>
             <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Content Zone</p>
-            <h2 className="text-3xl font-display">Enemy Authoring</h2>
+            <h2 className="text-3xl font-display">Item Authoring</h2>
             <p className="mt-2 text-sm text-slate-300 max-w-2xl">
-              Create and revise enemy content with the wizard flows below.
+              Build and revise item records through the creation and update wizards.
             </p>
           </div>
           <div className="text-right text-xs text-slate-400">
             <p>Database</p>
-            <p className="text-aurora-cyan">adventure.enemies</p>
+            <p className="text-aurora-cyan">adventure.items</p>
           </div>
         </div>
       </section>
@@ -20,36 +20,36 @@ export function EnemiesPage() {
       <section className="grid lg:grid-cols-2 gap-6">
         <div className="glass-panel rounded-3xl p-6">
           <div className="flex items-center justify-between">
-            <h3 className="text-xl font-display">Enemy Creation Flow</h3>
+            <h3 className="text-xl font-display">Item Creation Flow</h3>
             <span className="text-xs text-aurora-lime">Wizard Draft</span>
           </div>
           <ol className="mt-6 grid gap-4 text-sm text-slate-300">
             <li className="flex gap-3">
               <span className="text-aurora-cyan font-semibold">01</span>
               <div>
-                <p className="text-white">Base Identity</p>
-                <p>Name, role, lore description, images, difficulty tier.</p>
+                <p className="text-white">Identity & Art</p>
+                <p>Name, item type, rarity tier, icon, and flavor description.</p>
               </div>
             </li>
             <li className="flex gap-3">
               <span className="text-aurora-violet font-semibold">02</span>
               <div>
-                <p className="text-white">Stat Blueprint</p>
-                <p>HP/MP, attack/magic, defenses, accuracy, evasion, speed/ATB.</p>
+                <p className="text-white">Effect Payload</p>
+                <p>JSON effects, target type, usage limits, and cooldown behavior.</p>
               </div>
             </li>
             <li className="flex gap-3">
               <span className="text-aurora-magenta font-semibold">03</span>
               <div>
-                <p className="text-white">Ability Rotation</p>
-                <p>Assign abilities, weights, scaling stats, healing thresholds.</p>
+                <p className="text-white">Economy</p>
+                <p>Price bands, vendor stock defaults, and sell ratios.</p>
               </div>
             </li>
             <li className="flex gap-3">
               <span className="text-aurora-amber font-semibold">04</span>
               <div>
-                <p className="text-white">Resistances & Drops</p>
-                <p>Element relations, loot table, gil/xp reward defaults.</p>
+                <p className="text-white">Distribution</p>
+                <p>Attach to vendors, enemy drop tables, and loot chests.</p>
               </div>
             </li>
           </ol>
@@ -57,7 +57,7 @@ export function EnemiesPage() {
 
         <div className="glass-panel rounded-3xl p-6">
           <div className="flex items-center justify-between">
-            <h3 className="text-xl font-display">Enemy Update Flow</h3>
+            <h3 className="text-xl font-display">Item Update Flow</h3>
             <span className="text-xs text-aurora-lime">Wizard Draft</span>
           </div>
           <ol className="mt-6 grid gap-4 text-sm text-slate-300">
@@ -65,28 +65,28 @@ export function EnemiesPage() {
               <span className="text-aurora-cyan font-semibold">01</span>
               <div>
                 <p className="text-white">Select Target</p>
-                <p>Search by name, role, or internal ID to load a record.</p>
+                <p>Search by name or item type to load an entry.</p>
               </div>
             </li>
             <li className="flex gap-2">
               <span className="text-aurora-violet font-semibold">02</span>
               <div>
-                <p className="text-white">Patch Stats</p>
-                <p>Adjust HP/MP, offense/defense, speed, and reward outputs.</p>
+                <p className="text-white">Patch Core Data</p>
+                <p>Update item effect payload, usage limit, and pricing.</p>
               </div>
             </li>
             <li className="flex gap-2">
               <span className="text-aurora-magenta font-semibold">03</span>
               <div>
-                <p className="text-white">Revise Behaviors</p>
-                <p>Update ability weights, resistances, and drop tables.</p>
+                <p className="text-white">Revise Placement</p>
+                <p>Adjust vendor availability and drop table placement.</p>
               </div>
             </li>
             <li className="flex gap-2">
               <span className="text-aurora-amber font-semibold">04</span>
               <div>
                 <p className="text-white">Publish</p>
-                <p>Review deltas and push updates to the content table.</p>
+                <p>Review changes and save to the live item catalog.</p>
               </div>
             </li>
           </ol>


### PR DESCRIPTION
### Motivation
- Reduce visual clutter on authoring pages by removing redundant schema, stats, and explanatory guardrail content.  
- Focus the toolsuite on the actual creation and update wizards for content types so authors can create/modify entries quickly.  
- Preserve lightweight database context while trimming “state the obvious” developer copy.  
- Enable sidebar-driven view switching inside the app without changing routes.

### Description
- Trimmed `EnemiesPage`, and replaced the former `ItemsPage`, `AbilitiesPage`, and `ClassesPage` content with focused creation and update wizard flows.  
- Removed stat cards, schema tables, related-tables panels, and lengthy guardrail copy from those pages to keep the UI concise.  
- Updated `Layout` to accept `active` and `onNavChange` props and updated `Sidebar` to accept an `onSelect` callback and invoke it on button clicks.  
- Updated `App` to manage the active view with `useState`/`useMemo` and render the selected page (`Items`, `Classes`, `Abilities`, or `Enemies`).

### Testing
- Ran `npm install` in `adventure-tools` which completed successfully.  
- Started the dev server with `npm run dev` and Vite reported the local and network URLs.  
- Executed a Playwright script that opened the running app, clicked the `Items` button, and saved a screenshot to `artifacts/items-page.png`, which completed successfully.  
- No automated unit tests were added or run as this is a UI/content simplification change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b4713b01c8328b44a2175744de705)