### PR TITLE
Add page stubs and wire navigation for new adventure tool sections

### DIFF
--- a/adventure-tools/src/pages/App.tsx
+++ b/adventure-tools/src/pages/App.tsx
@@ -2,19 +2,37 @@ import { useMemo, useState } from "react";
 import { Layout } from "../components/Layout";
 import { AbilitiesPage } from "./AbilitiesPage";
 import { ClassesPage } from "./ClassesPage";
+import { EidolonsPage } from "./EidolonsPage";
 import { EnemiesPage } from "./EnemiesPage";
 import { ItemsPage } from "./ItemsPage";
+import { OverviewPage } from "./OverviewPage";
+import { ResistancesPage } from "./ResistancesPage";
+import { RoomTemplatesPage } from "./RoomTemplatesPage";
+import { TranceAbilitiesPage } from "./TranceAbilitiesPage";
+import { VendorsPage } from "./VendorsPage";
 
 export function App() {
   const [active, setActive] = useState("Enemies");
   const content = useMemo(() => {
     switch (active) {
+      case "Overview":
+        return <OverviewPage />;
       case "Items":
         return <ItemsPage />;
       case "Classes":
         return <ClassesPage />;
       case "Abilities":
         return <AbilitiesPage />;
+      case "Resistances":
+        return <ResistancesPage />;
+      case "Room Templates":
+        return <RoomTemplatesPage />;
+      case "Eidolons":
+        return <EidolonsPage />;
+      case "Trance Abilities":
+        return <TranceAbilitiesPage />;
+      case "Vendors":
+        return <VendorsPage />;
       case "Enemies":
       default:
         return <EnemiesPage />;

--- a/adventure-tools/src/pages/EidolonsPage.tsx
+++ b/adventure-tools/src/pages/EidolonsPage.tsx
@@ -1,0 +1,97 @@
+export function EidolonsPage() {
+  return (
+    <div className="space-y-8">
+      <section className="glass-panel rounded-3xl p-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Summon Studio</p>
+            <h2 className="text-3xl font-display">Eidolon Authoring</h2>
+            <p className="mt-2 text-sm text-slate-300 max-w-2xl">
+              Craft summon profiles, signature abilities, and bond progression milestones.
+            </p>
+          </div>
+          <div className="text-right text-xs text-slate-400">
+            <p>Database</p>
+            <p className="text-aurora-cyan">adventure.eidolons</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid lg:grid-cols-2 gap-6">
+        <div className="glass-panel rounded-3xl p-6">
+          <div className="flex items-center justify-between">
+            <h3 className="text-xl font-display">Eidolon Creation Flow</h3>
+            <span className="text-xs text-aurora-lime">Wizard Draft</span>
+          </div>
+          <ol className="mt-6 grid gap-4 text-sm text-slate-300">
+            <li className="flex gap-3">
+              <span className="text-aurora-cyan font-semibold">01</span>
+              <div>
+                <p className="text-white">Identity</p>
+                <p>Name, avatar, lore capsule, and core fantasy.</p>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-aurora-violet font-semibold">02</span>
+              <div>
+                <p className="text-white">Base Kit</p>
+                <p>Define stats, passive traits, and summon cadence.</p>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-aurora-magenta font-semibold">03</span>
+              <div>
+                <p className="text-white">Signature Abilities</p>
+                <p>Attach ultimate skills and linked elemental types.</p>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-aurora-amber font-semibold">04</span>
+              <div>
+                <p className="text-white">Bond Progression</p>
+                <p>Set unlock tiers, upgrade perks, and visuals.</p>
+              </div>
+            </li>
+          </ol>
+        </div>
+
+        <div className="glass-panel rounded-3xl p-6">
+          <div className="flex items-center justify-between">
+            <h3 className="text-xl font-display">Eidolon Update Flow</h3>
+            <span className="text-xs text-aurora-lime">Wizard Draft</span>
+          </div>
+          <ol className="mt-6 grid gap-4 text-sm text-slate-300">
+            <li className="flex gap-2">
+              <span className="text-aurora-cyan font-semibold">01</span>
+              <div>
+                <p className="text-white">Select Eidolon</p>
+                <p>Search by name or resonance ID.</p>
+              </div>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-aurora-violet font-semibold">02</span>
+              <div>
+                <p className="text-white">Patch Kit</p>
+                <p>Adjust base stats, summoning costs, and cooldowns.</p>
+              </div>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-aurora-magenta font-semibold">03</span>
+              <div>
+                <p className="text-white">Reassign Abilities</p>
+                <p>Swap signature moves or add new upgrade ranks.</p>
+              </div>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-aurora-amber font-semibold">04</span>
+              <div>
+                <p className="text-white">Publish</p>
+                <p>Review the diff and push the updated summon.</p>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/adventure-tools/src/pages/OverviewPage.tsx
+++ b/adventure-tools/src/pages/OverviewPage.tsx
@@ -1,0 +1,97 @@
+export function OverviewPage() {
+  return (
+    <div className="space-y-8">
+      <section className="glass-panel rounded-3xl p-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Command Center</p>
+            <h2 className="text-3xl font-display">Adventure Overview</h2>
+            <p className="mt-2 text-sm text-slate-300 max-w-2xl">
+              Monitor content pipelines, staging queues, and upcoming authoring milestones.
+            </p>
+          </div>
+          <div className="text-right text-xs text-slate-400">
+            <p>Status</p>
+            <p className="text-aurora-cyan">6 modules live</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid lg:grid-cols-2 gap-6">
+        <div className="glass-panel rounded-3xl p-6">
+          <div className="flex items-center justify-between">
+            <h3 className="text-xl font-display">Pipeline Health</h3>
+            <span className="text-xs text-aurora-lime">Live Sync</span>
+          </div>
+          <ol className="mt-6 grid gap-4 text-sm text-slate-300">
+            <li className="flex gap-3">
+              <span className="text-aurora-cyan font-semibold">01</span>
+              <div>
+                <p className="text-white">Authoring Queue</p>
+                <p>24 drafts waiting for review across enemies, items, and classes.</p>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-aurora-violet font-semibold">02</span>
+              <div>
+                <p className="text-white">Balance Review</p>
+                <p>5 balance passes scheduled for resistances and eidolon kits.</p>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-aurora-magenta font-semibold">03</span>
+              <div>
+                <p className="text-white">Lore Alignment</p>
+                <p>2 story beats flagged for narrative approval.</p>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-aurora-amber font-semibold">04</span>
+              <div>
+                <p className="text-white">Release Ready</p>
+                <p>12 assets queued for export into the nightly build.</p>
+              </div>
+            </li>
+          </ol>
+        </div>
+
+        <div className="glass-panel rounded-3xl p-6">
+          <div className="flex items-center justify-between">
+            <h3 className="text-xl font-display">Upcoming Milestones</h3>
+            <span className="text-xs text-aurora-lime">Next Sprint</span>
+          </div>
+          <ol className="mt-6 grid gap-4 text-sm text-slate-300">
+            <li className="flex gap-2">
+              <span className="text-aurora-cyan font-semibold">01</span>
+              <div>
+                <p className="text-white">Zone 7 Rooms</p>
+                <p>Finalize the room template set for the etheric sanctum.</p>
+              </div>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-aurora-violet font-semibold">02</span>
+              <div>
+                <p className="text-white">Vendor Refresh</p>
+                <p>Curate new item rotations and discount tables.</p>
+              </div>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-aurora-magenta font-semibold">03</span>
+              <div>
+                <p className="text-white">Trance Pass</p>
+                <p>Audit trance abilities for cooldown pacing and visuals.</p>
+              </div>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-aurora-amber font-semibold">04</span>
+              <div>
+                <p className="text-white">Launch Checklist</p>
+                <p>Lock copy, confirm localization, and export patch notes.</p>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/adventure-tools/src/pages/ResistancesPage.tsx
+++ b/adventure-tools/src/pages/ResistancesPage.tsx
@@ -1,0 +1,97 @@
+export function ResistancesPage() {
+  return (
+    <div className="space-y-8">
+      <section className="glass-panel rounded-3xl p-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Combat Matrix</p>
+            <h2 className="text-3xl font-display">Resistance Authoring</h2>
+            <p className="mt-2 text-sm text-slate-300 max-w-2xl">
+              Tune elemental strengths, vulnerabilities, and mitigation curves for every archetype.
+            </p>
+          </div>
+          <div className="text-right text-xs text-slate-400">
+            <p>Database</p>
+            <p className="text-aurora-cyan">adventure.resistances</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid lg:grid-cols-2 gap-6">
+        <div className="glass-panel rounded-3xl p-6">
+          <div className="flex items-center justify-between">
+            <h3 className="text-xl font-display">Resistance Matrix Builder</h3>
+            <span className="text-xs text-aurora-lime">Wizard Draft</span>
+          </div>
+          <ol className="mt-6 grid gap-4 text-sm text-slate-300">
+            <li className="flex gap-3">
+              <span className="text-aurora-cyan font-semibold">01</span>
+              <div>
+                <p className="text-white">Select Archetype</p>
+                <p>Assign the matrix to a class, enemy group, or eidolon.</p>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-aurora-violet font-semibold">02</span>
+              <div>
+                <p className="text-white">Element Weights</p>
+                <p>Set multipliers for fire, frost, shock, wind, and void.</p>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-aurora-magenta font-semibold">03</span>
+              <div>
+                <p className="text-white">Status Shields</p>
+                <p>Flag immunities, break thresholds, and cleanse triggers.</p>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-aurora-amber font-semibold">04</span>
+              <div>
+                <p className="text-white">Simulation Pass</p>
+                <p>Run sample encounters to verify mitigation curves.</p>
+              </div>
+            </li>
+          </ol>
+        </div>
+
+        <div className="glass-panel rounded-3xl p-6">
+          <div className="flex items-center justify-between">
+            <h3 className="text-xl font-display">Resistance Update Flow</h3>
+            <span className="text-xs text-aurora-lime">Wizard Draft</span>
+          </div>
+          <ol className="mt-6 grid gap-4 text-sm text-slate-300">
+            <li className="flex gap-2">
+              <span className="text-aurora-cyan font-semibold">01</span>
+              <div>
+                <p className="text-white">Load Matrix</p>
+                <p>Search by archetype or zone to fetch active settings.</p>
+              </div>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-aurora-violet font-semibold">02</span>
+              <div>
+                <p className="text-white">Patch Multipliers</p>
+                <p>Adjust elemental scaling and percentage caps.</p>
+              </div>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-aurora-magenta font-semibold">03</span>
+              <div>
+                <p className="text-white">Rebalance Status</p>
+                <p>Update cleanse thresholds and debuff durations.</p>
+              </div>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-aurora-amber font-semibold">04</span>
+              <div>
+                <p className="text-white">Publish</p>
+                <p>Validate combat output and release the new matrix.</p>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/adventure-tools/src/pages/RoomTemplatesPage.tsx
+++ b/adventure-tools/src/pages/RoomTemplatesPage.tsx
@@ -1,0 +1,97 @@
+export function RoomTemplatesPage() {
+  return (
+    <div className="space-y-8">
+      <section className="glass-panel rounded-3xl p-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-[0.3em] text-slate-400">World Builder</p>
+            <h2 className="text-3xl font-display">Room Template Authoring</h2>
+            <p className="mt-2 text-sm text-slate-300 max-w-2xl">
+              Design modular rooms with encounter hooks, loot drops, and traversal logic.
+            </p>
+          </div>
+          <div className="text-right text-xs text-slate-400">
+            <p>Database</p>
+            <p className="text-aurora-cyan">adventure.rooms</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid lg:grid-cols-2 gap-6">
+        <div className="glass-panel rounded-3xl p-6">
+          <div className="flex items-center justify-between">
+            <h3 className="text-xl font-display">Template Creation Flow</h3>
+            <span className="text-xs text-aurora-lime">Wizard Draft</span>
+          </div>
+          <ol className="mt-6 grid gap-4 text-sm text-slate-300">
+            <li className="flex gap-3">
+              <span className="text-aurora-cyan font-semibold">01</span>
+              <div>
+                <p className="text-white">Layout Blueprint</p>
+                <p>Pick geometry, exits, and encounter capacity.</p>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-aurora-violet font-semibold">02</span>
+              <div>
+                <p className="text-white">Room Theme</p>
+                <p>Assign biome, ambience, and prop collections.</p>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-aurora-magenta font-semibold">03</span>
+              <div>
+                <p className="text-white">Encounter Hooks</p>
+                <p>Define spawn tables, puzzles, or narrative triggers.</p>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-aurora-amber font-semibold">04</span>
+              <div>
+                <p className="text-white">Reward Tables</p>
+                <p>Attach loot, vendor portals, and relic drops.</p>
+              </div>
+            </li>
+          </ol>
+        </div>
+
+        <div className="glass-panel rounded-3xl p-6">
+          <div className="flex items-center justify-between">
+            <h3 className="text-xl font-display">Template Revision Flow</h3>
+            <span className="text-xs text-aurora-lime">Wizard Draft</span>
+          </div>
+          <ol className="mt-6 grid gap-4 text-sm text-slate-300">
+            <li className="flex gap-2">
+              <span className="text-aurora-cyan font-semibold">01</span>
+              <div>
+                <p className="text-white">Select Template</p>
+                <p>Search by biome or ID to load active room data.</p>
+              </div>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-aurora-violet font-semibold">02</span>
+              <div>
+                <p className="text-white">Patch Layout</p>
+                <p>Update exit rules, enemy cap, or traversal blockers.</p>
+              </div>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-aurora-magenta font-semibold">03</span>
+              <div>
+                <p className="text-white">Rebalance Hooks</p>
+                <p>Adjust spawn rates, puzzle timers, and narrative beats.</p>
+              </div>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-aurora-amber font-semibold">04</span>
+              <div>
+                <p className="text-white">Publish</p>
+                <p>Validate navigation graphs and save the new version.</p>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/adventure-tools/src/pages/TranceAbilitiesPage.tsx
+++ b/adventure-tools/src/pages/TranceAbilitiesPage.tsx
@@ -1,0 +1,97 @@
+export function TranceAbilitiesPage() {
+  return (
+    <div className="space-y-8">
+      <section className="glass-panel rounded-3xl p-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Energy Forge</p>
+            <h2 className="text-3xl font-display">Trance Ability Authoring</h2>
+            <p className="mt-2 text-sm text-slate-300 max-w-2xl">
+              Build trance-exclusive skill kits, visual overrides, and cooldown pacing.
+            </p>
+          </div>
+          <div className="text-right text-xs text-slate-400">
+            <p>Database</p>
+            <p className="text-aurora-cyan">adventure.trance_abilities</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid lg:grid-cols-2 gap-6">
+        <div className="glass-panel rounded-3xl p-6">
+          <div className="flex items-center justify-between">
+            <h3 className="text-xl font-display">Trance Kit Builder</h3>
+            <span className="text-xs text-aurora-lime">Wizard Draft</span>
+          </div>
+          <ol className="mt-6 grid gap-4 text-sm text-slate-300">
+            <li className="flex gap-3">
+              <span className="text-aurora-cyan font-semibold">01</span>
+              <div>
+                <p className="text-white">Select Class</p>
+                <p>Match the trance kit to its base class variant.</p>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-aurora-violet font-semibold">02</span>
+              <div>
+                <p className="text-white">Ability Set</p>
+                <p>Assign the trance-exclusive ability lineup.</p>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-aurora-magenta font-semibold">03</span>
+              <div>
+                <p className="text-white">Visual Overrides</p>
+                <p>Define VFX layers, palette swaps, and stance swaps.</p>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-aurora-amber font-semibold">04</span>
+              <div>
+                <p className="text-white">Cooldown Tuning</p>
+                <p>Balance trance duration and ability refresh timings.</p>
+              </div>
+            </li>
+          </ol>
+        </div>
+
+        <div className="glass-panel rounded-3xl p-6">
+          <div className="flex items-center justify-between">
+            <h3 className="text-xl font-display">Trance Update Flow</h3>
+            <span className="text-xs text-aurora-lime">Wizard Draft</span>
+          </div>
+          <ol className="mt-6 grid gap-4 text-sm text-slate-300">
+            <li className="flex gap-2">
+              <span className="text-aurora-cyan font-semibold">01</span>
+              <div>
+                <p className="text-white">Load Trance Kit</p>
+                <p>Find kits by class or trance code.</p>
+              </div>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-aurora-violet font-semibold">02</span>
+              <div>
+                <p className="text-white">Patch Abilities</p>
+                <p>Swap out abilities or adjust potency values.</p>
+              </div>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-aurora-magenta font-semibold">03</span>
+              <div>
+                <p className="text-white">Adjust Visuals</p>
+                <p>Update VFX set, aura intensity, or stance overlays.</p>
+              </div>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-aurora-amber font-semibold">04</span>
+              <div>
+                <p className="text-white">Publish</p>
+                <p>Review changes and push the trance update.</p>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/adventure-tools/src/pages/VendorsPage.tsx
+++ b/adventure-tools/src/pages/VendorsPage.tsx
@@ -1,0 +1,97 @@
+export function VendorsPage() {
+  return (
+    <div className="space-y-8">
+      <section className="glass-panel rounded-3xl p-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Market Deck</p>
+            <h2 className="text-3xl font-display">Vendor Authoring</h2>
+            <p className="mt-2 text-sm text-slate-300 max-w-2xl">
+              Configure shop inventories, pricing tiers, and limited-time rotations.
+            </p>
+          </div>
+          <div className="text-right text-xs text-slate-400">
+            <p>Database</p>
+            <p className="text-aurora-cyan">adventure.vendors</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid lg:grid-cols-2 gap-6">
+        <div className="glass-panel rounded-3xl p-6">
+          <div className="flex items-center justify-between">
+            <h3 className="text-xl font-display">Vendor Creation Flow</h3>
+            <span className="text-xs text-aurora-lime">Wizard Draft</span>
+          </div>
+          <ol className="mt-6 grid gap-4 text-sm text-slate-300">
+            <li className="flex gap-3">
+              <span className="text-aurora-cyan font-semibold">01</span>
+              <div>
+                <p className="text-white">Identity</p>
+                <p>Name, location, portrait, and lore summary.</p>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-aurora-violet font-semibold">02</span>
+              <div>
+                <p className="text-white">Inventory Pool</p>
+                <p>Assign item groups, rarity caps, and stock limits.</p>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-aurora-magenta font-semibold">03</span>
+              <div>
+                <p className="text-white">Pricing Rules</p>
+                <p>Set markup, discounts, and barter multipliers.</p>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-aurora-amber font-semibold">04</span>
+              <div>
+                <p className="text-white">Rotation Schedule</p>
+                <p>Define refresh cadence, featured bundles, and bonuses.</p>
+              </div>
+            </li>
+          </ol>
+        </div>
+
+        <div className="glass-panel rounded-3xl p-6">
+          <div className="flex items-center justify-between">
+            <h3 className="text-xl font-display">Vendor Update Flow</h3>
+            <span className="text-xs text-aurora-lime">Wizard Draft</span>
+          </div>
+          <ol className="mt-6 grid gap-4 text-sm text-slate-300">
+            <li className="flex gap-2">
+              <span className="text-aurora-cyan font-semibold">01</span>
+              <div>
+                <p className="text-white">Select Vendor</p>
+                <p>Search by shop name or zone to load details.</p>
+              </div>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-aurora-violet font-semibold">02</span>
+              <div>
+                <p className="text-white">Patch Inventory</p>
+                <p>Swap items, adjust stock caps, or add bundles.</p>
+              </div>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-aurora-magenta font-semibold">03</span>
+              <div>
+                <p className="text-white">Tune Pricing</p>
+                <p>Modify discounts, currency conversions, and deals.</p>
+              </div>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-aurora-amber font-semibold">04</span>
+              <div>
+                <p className="text-white">Publish</p>
+                <p>Review the rotation and save the update.</p>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Surface new authoring sections in the sidebar so each nav label renders a corresponding page component.
- Provide consistent wizard-style UI stubs so designers and engineers can iterate on flows quickly.
- Prepare the front-end scaffolding for resistances, room templates, eidolons, trance abilities, vendors, and an overview/monitoring page.

### Description
- Add `OverviewPage`, `ResistancesPage`, `RoomTemplatesPage`, `EidolonsPage`, `TranceAbilitiesPage`, and `VendorsPage` under `adventure-tools/src/pages/` with wizard-style card layouts.
- Import and wire these components in `adventure-tools/src/pages/App.tsx` and map the sidebar labels (`Overview`, `Resistances`, `Room Templates`, `Eidolons`, `Trance Abilities`, `Vendors`) in the `switch (active)` block.
- Keep layout and visual structure consistent with existing pages like `AbilitiesPage` and `ClassesPage` to maintain UI coherence.
- No backend or data-model changes included; these are UI stubs only.

### Testing
- Ran `npm install` in the `adventure-tools` directory which completed successfully with audit warnings about vulnerabilities.
- Started the dev server via `npm run dev` and confirmed Vite served the app.
- Executed a Playwright script that opened the app, clicked the `Overview` nav button, and produced a screenshot (`artifacts/overview-page.png`) successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694baeccad988328811a504a1a87c4c4)