### PR TITLE
Add wizard form sections and shared form components for authoring pages

### DIFF
--- a/adventure-tools/src/components/FormField.tsx
+++ b/adventure-tools/src/components/FormField.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+
+export function FormField({
+  label,
+  htmlFor,
+  hint,
+  error,
+  children
+}: {
+  label: string;
+  htmlFor?: string;
+  hint?: string;
+  error?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <label className="text-sm font-semibold text-slate-100" htmlFor={htmlFor}>
+          {label}
+        </label>
+        {hint ? <span className="text-xs text-slate-400">{hint}</span> : null}
+      </div>
+      {children}
+      {error ? <p className="text-xs text-aurora-amber">{error}</p> : null}
+    </div>
+  );
+}

--- a/adventure-tools/src/components/JsonEditor.tsx
+++ b/adventure-tools/src/components/JsonEditor.tsx
@@ -1,0 +1,29 @@
+import { clsx } from "clsx";
+
+export function JsonEditor({
+  id,
+  value,
+  onChange,
+  placeholder,
+  invalid
+}: {
+  id?: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  invalid?: boolean;
+}) {
+  return (
+    <textarea
+      id={id}
+      className={clsx(
+        "min-h-[140px] w-full rounded-2xl border px-4 py-3 text-sm font-mono bg-night-900/60",
+        "focus:outline-none focus:ring-2 focus:ring-aurora-violet/70",
+        invalid ? "border-aurora-amber/60" : "border-white/10"
+      )}
+      placeholder={placeholder}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    />
+  );
+}

--- a/adventure-tools/src/components/WizardActions.tsx
+++ b/adventure-tools/src/components/WizardActions.tsx
@@ -1,0 +1,31 @@
+export function WizardActions({
+  onSaveDraft,
+  onPublish,
+  message
+}: {
+  onSaveDraft: () => void;
+  onPublish: () => void;
+  message?: string;
+}) {
+  return (
+    <div className="border-t border-white/10 pt-4 flex flex-wrap items-center justify-between gap-4">
+      {message ? <p className="text-xs text-slate-300">{message}</p> : <span />}
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          className="px-4 py-2 rounded-full border border-white/10 bg-white/5 text-sm text-white"
+          onClick={onSaveDraft}
+        >
+          Save draft
+        </button>
+        <button
+          type="button"
+          className="px-4 py-2 rounded-full bg-aurora-violet/80 text-sm text-white shadow-glow"
+          onClick={onPublish}
+        >
+          Publish
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/adventure-tools/src/components/WizardSection.tsx
+++ b/adventure-tools/src/components/WizardSection.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+
+export function WizardSection({
+  title,
+  badge,
+  description,
+  children
+}: {
+  title: string;
+  badge?: string;
+  description?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="glass-panel rounded-3xl p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-xl font-display">{title}</h3>
+          {description ? <p className="mt-2 text-sm text-slate-300">{description}</p> : null}
+        </div>
+        {badge ? <span className="text-xs text-aurora-lime">{badge}</span> : null}
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/adventure-tools/src/pages/AbilitiesPage.tsx
+++ b/adventure-tools/src/pages/AbilitiesPage.tsx
@@ -1,4 +1,111 @@
+import { useState } from "react";
+import { FormField } from "../components/FormField";
+import { JsonEditor } from "../components/JsonEditor";
+import { WizardActions } from "../components/WizardActions";
+import { WizardSection } from "../components/WizardSection";
+
+const inputClassName =
+  "w-full rounded-2xl border border-white/10 bg-night-900/60 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-aurora-violet/70";
+
+const textareaClassName = `${inputClassName} min-h-[120px]`;
+
+const isValidJson = (value: string) => {
+  if (!value.trim()) {
+    return "JSON is required.";
+  }
+  try {
+    JSON.parse(value);
+    return "";
+  } catch {
+    return "Enter valid JSON.";
+  }
+};
+
+type AbilityCreateForm = {
+  name: string;
+  icon: string;
+  target: string;
+  element: string;
+  trigger: string;
+  description: string;
+  effectJson: string;
+  mpCost: string;
+  cooldown: string;
+  distributionJson: string;
+};
+
+type AbilityUpdateForm = {
+  target: string;
+  scalingStat: string;
+  effectJson: string;
+  distributionJson: string;
+};
+
+const initialCreateForm: AbilityCreateForm = {
+  name: "",
+  icon: "",
+  target: "",
+  element: "",
+  trigger: "manual",
+  description: "",
+  effectJson: "{\n  \"formula\": \"\",\n  \"status\": []\n}",
+  mpCost: "",
+  cooldown: "",
+  distributionJson: "{\n  \"classes\": [],\n  \"enemies\": []\n}"
+};
+
+const initialUpdateForm: AbilityUpdateForm = {
+  target: "",
+  scalingStat: "",
+  effectJson: "{\n  \"formula\": \"\",\n  \"status\": []\n}",
+  distributionJson: "{\n  \"classes\": [],\n  \"enemies\": []\n}"
+};
+
 export function AbilitiesPage() {
+  const [createForm, setCreateForm] = useState(initialCreateForm);
+  const [updateForm, setUpdateForm] = useState(initialUpdateForm);
+  const [createTouched, setCreateTouched] = useState(false);
+  const [updateTouched, setUpdateTouched] = useState(false);
+  const [createMessage, setCreateMessage] = useState("");
+  const [updateMessage, setUpdateMessage] = useState("");
+
+  const createErrors = {
+    name: createForm.name.trim() ? "" : "Ability name is required.",
+    icon: createForm.icon.trim() ? "" : "Provide an icon reference.",
+    target: createForm.target ? "" : "Select a targeting rule.",
+    element: createForm.element ? "" : "Select an element.",
+    description: createForm.description.trim() ? "" : "Add a short description.",
+    effectJson: isValidJson(createForm.effectJson),
+    mpCost:
+      createForm.mpCost && Number(createForm.mpCost) >= 0
+        ? ""
+        : "Enter an MP cost.",
+    cooldown:
+      createForm.cooldown && Number(createForm.cooldown) >= 0
+        ? ""
+        : "Enter a cooldown value.",
+    distributionJson: isValidJson(createForm.distributionJson)
+  };
+
+  const updateErrors = {
+    target: updateForm.target.trim() ? "" : "Select an ability to update.",
+    scalingStat: updateForm.scalingStat ? "" : "Choose a scaling stat.",
+    effectJson: isValidJson(updateForm.effectJson),
+    distributionJson: isValidJson(updateForm.distributionJson)
+  };
+
+  const handleCreateAction = (message: string) => {
+    setCreateTouched(true);
+    const hasErrors = Object.values(createErrors).some((error) => error);
+    setCreateMessage(hasErrors ? "Resolve validation errors before continuing." : message);
+  };
+
+  const handleUpdateAction = (message: string) => {
+    setUpdateTouched(true);
+    const hasErrors = Object.values(updateErrors).some((error) => error);
+    setUpdateMessage(hasErrors ? "Resolve validation errors before continuing." : message);
+  };
+
   return (
     <div className="space-y-8">
       <section className="glass-panel rounded-3xl p-6">
@@ -18,79 +125,240 @@ export function AbilitiesPage() {
       </section>
 
       <section className="grid lg:grid-cols-2 gap-6">
-        <div className="glass-panel rounded-3xl p-6">
-          <div className="flex items-center justify-between">
-            <h3 className="text-xl font-display">Ability Creation Flow</h3>
-            <span className="text-xs text-aurora-lime">Wizard Draft</span>
+        <WizardSection
+          title="Ability Creation"
+          badge="Wizard Draft"
+          description="Define identity, effect payloads, and distribution targets."
+        >
+          <div className="grid gap-4">
+            <FormField
+              label="Ability name"
+              htmlFor="ability-name"
+              error={createTouched ? createErrors.name : undefined}
+            >
+              <input
+                id="ability-name"
+                className={inputClassName}
+                value={createForm.name}
+                onChange={(event) => setCreateForm({ ...createForm, name: event.target.value })}
+                placeholder="Solar Flare"
+              />
+            </FormField>
+            <div className="grid gap-4 md:grid-cols-2">
+              <FormField
+                label="Icon asset"
+                htmlFor="ability-icon"
+                error={createTouched ? createErrors.icon : undefined}
+              >
+                <input
+                  id="ability-icon"
+                  className={inputClassName}
+                  value={createForm.icon}
+                  onChange={(event) => setCreateForm({ ...createForm, icon: event.target.value })}
+                  placeholder="icons/flare.svg"
+                />
+              </FormField>
+              <FormField
+                label="Targeting"
+                htmlFor="ability-target"
+                error={createTouched ? createErrors.target : undefined}
+              >
+                <select
+                  id="ability-target"
+                  className={inputClassName}
+                  value={createForm.target}
+                  onChange={(event) => setCreateForm({ ...createForm, target: event.target.value })}
+                >
+                  <option value="">Select target</option>
+                  <option value="single">Single Target</option>
+                  <option value="aoe">Area of Effect</option>
+                  <option value="self">Self</option>
+                  <option value="ally">Ally</option>
+                </select>
+              </FormField>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              <FormField
+                label="Element"
+                htmlFor="ability-element"
+                error={createTouched ? createErrors.element : undefined}
+              >
+                <select
+                  id="ability-element"
+                  className={inputClassName}
+                  value={createForm.element}
+                  onChange={(event) =>
+                    setCreateForm({ ...createForm, element: event.target.value })
+                  }
+                >
+                  <option value="">Select element</option>
+                  <option value="fire">Fire</option>
+                  <option value="ice">Ice</option>
+                  <option value="lightning">Lightning</option>
+                  <option value="holy">Holy</option>
+                  <option value="shadow">Shadow</option>
+                </select>
+              </FormField>
+              <FormField
+                label="MP cost"
+                htmlFor="ability-mp"
+                error={createTouched ? createErrors.mpCost : undefined}
+              >
+                <input
+                  id="ability-mp"
+                  type="number"
+                  className={inputClassName}
+                  value={createForm.mpCost}
+                  onChange={(event) => setCreateForm({ ...createForm, mpCost: event.target.value })}
+                />
+              </FormField>
+            </div>
+            <FormField
+              label="Description"
+              htmlFor="ability-description"
+              error={createTouched ? createErrors.description : undefined}
+            >
+              <textarea
+                id="ability-description"
+                className={textareaClassName}
+                value={createForm.description}
+                onChange={(event) =>
+                  setCreateForm({ ...createForm, description: event.target.value })
+                }
+                placeholder="Short combat flavor text."
+              />
+            </FormField>
+            <FormField
+              label="Effect builder"
+              hint="JSON"
+              error={createTouched ? createErrors.effectJson : undefined}
+            >
+              <JsonEditor
+                value={createForm.effectJson}
+                onChange={(value) => setCreateForm({ ...createForm, effectJson: value })}
+                invalid={createTouched && Boolean(createErrors.effectJson)}
+              />
+            </FormField>
+            <div className="grid gap-4 md:grid-cols-2">
+              <FormField
+                label="Cooldown (turns)"
+                htmlFor="ability-cooldown"
+                error={createTouched ? createErrors.cooldown : undefined}
+              >
+                <input
+                  id="ability-cooldown"
+                  type="number"
+                  className={inputClassName}
+                  value={createForm.cooldown}
+                  onChange={(event) =>
+                    setCreateForm({ ...createForm, cooldown: event.target.value })
+                  }
+                />
+              </FormField>
+              <FormField label="Auto-trigger" htmlFor="ability-trigger">
+                <select
+                  id="ability-trigger"
+                  className={inputClassName}
+                  value={createForm.trigger}
+                  onChange={(event) =>
+                    setCreateForm({ ...createForm, trigger: event.target.value })
+                  }
+                >
+                  <option value="manual">Manual cast</option>
+                  <option value="on-hit">Trigger on hit</option>
+                  <option value="low-health">Trigger under 30% HP</option>
+                </select>
+              </FormField>
+            </div>
+            <FormField
+              label="Distribution"
+              hint="JSON"
+              error={createTouched ? createErrors.distributionJson : undefined}
+            >
+              <JsonEditor
+                value={createForm.distributionJson}
+                onChange={(value) => setCreateForm({ ...createForm, distributionJson: value })}
+                invalid={createTouched && Boolean(createErrors.distributionJson)}
+              />
+            </FormField>
           </div>
-          <ol className="mt-6 grid gap-4 text-sm text-slate-300">
-            <li className="flex gap-3">
-              <span className="text-aurora-cyan font-semibold">01</span>
-              <div>
-                <p className="text-white">Identity</p>
-                <p>Name, icon, description, and targeting rules.</p>
-              </div>
-            </li>
-            <li className="flex gap-3">
-              <span className="text-aurora-violet font-semibold">02</span>
-              <div>
-                <p className="text-white">Effect Builder</p>
-                <p>Damage/heal formulas, status payload, scaling stat, and element link.</p>
-              </div>
-            </li>
-            <li className="flex gap-3">
-              <span className="text-aurora-magenta font-semibold">03</span>
-              <div>
-                <p className="text-white">Cost & Cooldown</p>
-                <p>MP cost, cooldown turns, and special effect triggers.</p>
-              </div>
-            </li>
-            <li className="flex gap-3">
-              <span className="text-aurora-amber font-semibold">04</span>
-              <div>
-                <p className="text-white">Distribution</p>
-                <p>Assign to classes, enemies, eidolons, or trance states.</p>
-              </div>
-            </li>
-          </ol>
-        </div>
+          <WizardActions
+            message={createMessage}
+            onSaveDraft={() => handleCreateAction("Draft saved for ability creation.")}
+            onPublish={() => handleCreateAction("Ability creation draft queued for publish.")}
+          />
+        </WizardSection>
 
-        <div className="glass-panel rounded-3xl p-6">
-          <div className="flex items-center justify-between">
-            <h3 className="text-xl font-display">Ability Update Flow</h3>
-            <span className="text-xs text-aurora-lime">Wizard Draft</span>
+        <WizardSection
+          title="Ability Update"
+          badge="Wizard Draft"
+          description="Revise live abilities, formulas, and assignment overrides."
+        >
+          <div className="grid gap-4">
+            <FormField
+              label="Target ability"
+              htmlFor="ability-target-update"
+              error={updateTouched ? updateErrors.target : undefined}
+            >
+              <input
+                id="ability-target-update"
+                className={inputClassName}
+                value={updateForm.target}
+                onChange={(event) => setUpdateForm({ ...updateForm, target: event.target.value })}
+                placeholder="Search by name or ID"
+              />
+            </FormField>
+            <FormField
+              label="Scaling stat"
+              htmlFor="ability-scaling"
+              error={updateTouched ? updateErrors.scalingStat : undefined}
+            >
+              <select
+                id="ability-scaling"
+                className={inputClassName}
+                value={updateForm.scalingStat}
+                onChange={(event) =>
+                  setUpdateForm({ ...updateForm, scalingStat: event.target.value })
+                }
+              >
+                <option value="">Select stat</option>
+                <option value="strength">Strength</option>
+                <option value="magic">Magic</option>
+                <option value="spirit">Spirit</option>
+                <option value="dexterity">Dexterity</option>
+              </select>
+            </FormField>
+            <FormField
+              label="Effect patch"
+              hint="JSON"
+              error={updateTouched ? updateErrors.effectJson : undefined}
+            >
+              <JsonEditor
+                value={updateForm.effectJson}
+                onChange={(value) => setUpdateForm({ ...updateForm, effectJson: value })}
+                invalid={updateTouched && Boolean(updateErrors.effectJson)}
+              />
+            </FormField>
+            <FormField
+              label="Distribution patch"
+              hint="JSON"
+              error={updateTouched ? updateErrors.distributionJson : undefined}
+            >
+              <JsonEditor
+                value={updateForm.distributionJson}
+                onChange={(value) =>
+                  setUpdateForm({ ...updateForm, distributionJson: value })
+                }
+                invalid={updateTouched && Boolean(updateErrors.distributionJson)}
+              />
+            </FormField>
           </div>
-          <ol className="mt-6 grid gap-4 text-sm text-slate-300">
-            <li className="flex gap-2">
-              <span className="text-aurora-cyan font-semibold">01</span>
-              <div>
-                <p className="text-white">Select Target</p>
-                <p>Search by name or ability ID to load the record.</p>
-              </div>
-            </li>
-            <li className="flex gap-2">
-              <span className="text-aurora-violet font-semibold">02</span>
-              <div>
-                <p className="text-white">Patch Core Data</p>
-                <p>Update effects, costs, cooldowns, and scaling stats.</p>
-              </div>
-            </li>
-            <li className="flex gap-2">
-              <span className="text-aurora-magenta font-semibold">03</span>
-              <div>
-                <p className="text-white">Re-assign</p>
-                <p>Adjust class, enemy, or eidolon allocations.</p>
-              </div>
-            </li>
-            <li className="flex gap-2">
-              <span className="text-aurora-amber font-semibold">04</span>
-              <div>
-                <p className="text-white">Publish</p>
-                <p>Review the diff and save the updated ability.</p>
-              </div>
-            </li>
-          </ol>
-        </div>
+          <WizardActions
+            message={updateMessage}
+            onSaveDraft={() => handleUpdateAction("Draft saved for ability update.")}
+            onPublish={() => handleUpdateAction("Ability update draft queued for publish.")}
+          />
+        </WizardSection>
       </section>
     </div>
   );

--- a/adventure-tools/src/pages/ClassesPage.tsx
+++ b/adventure-tools/src/pages/ClassesPage.tsx
@@ -1,4 +1,120 @@
+import { useState } from "react";
+import { FormField } from "../components/FormField";
+import { JsonEditor } from "../components/JsonEditor";
+import { WizardActions } from "../components/WizardActions";
+import { WizardSection } from "../components/WizardSection";
+
+const inputClassName =
+  "w-full rounded-2xl border border-white/10 bg-night-900/60 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-aurora-violet/70";
+
+const textareaClassName = `${inputClassName} min-h-[120px]`;
+
+const isValidJson = (value: string) => {
+  if (!value.trim()) {
+    return "JSON is required.";
+  }
+  try {
+    JSON.parse(value);
+    return "";
+  } catch {
+    return "Enter valid JSON.";
+  }
+};
+
+type ClassCreateForm = {
+  name: string;
+  role: string;
+  style: string;
+  lore: string;
+  baseHp: string;
+  baseMp: string;
+  speed: string;
+  progressionJson: string;
+  tranceJson: string;
+};
+
+type ClassUpdateForm = {
+  target: string;
+  patchHp: string;
+  patchMp: string;
+  unlocksJson: string;
+  tranceJson: string;
+};
+
+const initialCreateForm: ClassCreateForm = {
+  name: "",
+  role: "",
+  style: "regal",
+  lore: "",
+  baseHp: "",
+  baseMp: "",
+  speed: "",
+  progressionJson: "{\n  \"levels\": []\n}",
+  tranceJson: "{\n  \"duration\": 0,\n  \"overrides\": {}\n}"
+};
+
+const initialUpdateForm: ClassUpdateForm = {
+  target: "",
+  patchHp: "",
+  patchMp: "",
+  unlocksJson: "{\n  \"levels\": []\n}",
+  tranceJson: "{\n  \"duration\": 0,\n  \"overrides\": {}\n}"
+};
+
 export function ClassesPage() {
+  const [createForm, setCreateForm] = useState(initialCreateForm);
+  const [updateForm, setUpdateForm] = useState(initialUpdateForm);
+  const [createTouched, setCreateTouched] = useState(false);
+  const [updateTouched, setUpdateTouched] = useState(false);
+  const [createMessage, setCreateMessage] = useState("");
+  const [updateMessage, setUpdateMessage] = useState("");
+
+  const createErrors = {
+    name: createForm.name.trim() ? "" : "Class name is required.",
+    role: createForm.role ? "" : "Select a role archetype.",
+    lore: createForm.lore.trim() ? "" : "Provide lore for the class.",
+    baseHp:
+      createForm.baseHp && Number(createForm.baseHp) > 0
+        ? ""
+        : "Enter a positive HP value.",
+    baseMp:
+      createForm.baseMp && Number(createForm.baseMp) >= 0
+        ? ""
+        : "Enter a non-negative MP value.",
+    speed:
+      createForm.speed && Number(createForm.speed) > 0
+        ? ""
+        : "Enter a positive speed value.",
+    progressionJson: isValidJson(createForm.progressionJson),
+    tranceJson: isValidJson(createForm.tranceJson)
+  };
+
+  const updateErrors = {
+    target: updateForm.target.trim() ? "" : "Select a class to update.",
+    patchHp:
+      !updateForm.patchHp || Number(updateForm.patchHp) > 0
+        ? ""
+        : "Enter a positive HP value.",
+    patchMp:
+      !updateForm.patchMp || Number(updateForm.patchMp) >= 0
+        ? ""
+        : "Enter a non-negative MP value.",
+    unlocksJson: isValidJson(updateForm.unlocksJson),
+    tranceJson: isValidJson(updateForm.tranceJson)
+  };
+
+  const handleCreateAction = (message: string) => {
+    setCreateTouched(true);
+    const hasErrors = Object.values(createErrors).some((error) => error);
+    setCreateMessage(hasErrors ? "Resolve validation errors before continuing." : message);
+  };
+
+  const handleUpdateAction = (message: string) => {
+    setUpdateTouched(true);
+    const hasErrors = Object.values(updateErrors).some((error) => error);
+    setUpdateMessage(hasErrors ? "Resolve validation errors before continuing." : message);
+  };
+
   return (
     <div className="space-y-8">
       <section className="glass-panel rounded-3xl p-6">
@@ -18,79 +134,232 @@ export function ClassesPage() {
       </section>
 
       <section className="grid lg:grid-cols-2 gap-6">
-        <div className="glass-panel rounded-3xl p-6">
-          <div className="flex items-center justify-between">
-            <h3 className="text-xl font-display">Class Creation Flow</h3>
-            <span className="text-xs text-aurora-lime">Wizard Draft</span>
+        <WizardSection
+          title="Class Creation"
+          badge="Wizard Draft"
+          description="Capture class fantasy, base stats, and progression milestones."
+        >
+          <div className="grid gap-4">
+            <FormField
+              label="Class name"
+              htmlFor="class-name"
+              error={createTouched ? createErrors.name : undefined}
+            >
+              <input
+                id="class-name"
+                className={inputClassName}
+                value={createForm.name}
+                onChange={(event) => setCreateForm({ ...createForm, name: event.target.value })}
+                placeholder="Skyward Knight"
+              />
+            </FormField>
+            <div className="grid gap-4 md:grid-cols-2">
+              <FormField
+                label="Role archetype"
+                htmlFor="class-role"
+                error={createTouched ? createErrors.role : undefined}
+              >
+                <select
+                  id="class-role"
+                  className={inputClassName}
+                  value={createForm.role}
+                  onChange={(event) => setCreateForm({ ...createForm, role: event.target.value })}
+                >
+                  <option value="">Select role</option>
+                  <option value="tank">Tank</option>
+                  <option value="support">Support</option>
+                  <option value="damage">Damage</option>
+                  <option value="hybrid">Hybrid</option>
+                </select>
+              </FormField>
+              <FormField label="Visual identity" htmlFor="class-style">
+                <select
+                  id="class-style"
+                  className={inputClassName}
+                  value={createForm.style}
+                  onChange={(event) =>
+                    setCreateForm({ ...createForm, style: event.target.value })
+                  }
+                >
+                  <option value="regal">Regal</option>
+                  <option value="arcane">Arcane</option>
+                  <option value="rogue">Rogue</option>
+                  <option value="mystic">Mystic</option>
+                </select>
+              </FormField>
+            </div>
+            <FormField
+              label="Lore description"
+              htmlFor="class-lore"
+              error={createTouched ? createErrors.lore : undefined}
+            >
+              <textarea
+                id="class-lore"
+                className={textareaClassName}
+                value={createForm.lore}
+                onChange={(event) => setCreateForm({ ...createForm, lore: event.target.value })}
+                placeholder="Story beat for the codex entry."
+              />
+            </FormField>
+            <div className="grid gap-4 md:grid-cols-3">
+              <FormField
+                label="Base HP"
+                htmlFor="class-hp"
+                error={createTouched ? createErrors.baseHp : undefined}
+              >
+                <input
+                  id="class-hp"
+                  type="number"
+                  className={inputClassName}
+                  value={createForm.baseHp}
+                  onChange={(event) =>
+                    setCreateForm({ ...createForm, baseHp: event.target.value })
+                  }
+                />
+              </FormField>
+              <FormField
+                label="Base MP"
+                htmlFor="class-mp"
+                error={createTouched ? createErrors.baseMp : undefined}
+              >
+                <input
+                  id="class-mp"
+                  type="number"
+                  className={inputClassName}
+                  value={createForm.baseMp}
+                  onChange={(event) =>
+                    setCreateForm({ ...createForm, baseMp: event.target.value })
+                  }
+                />
+              </FormField>
+              <FormField
+                label="Speed"
+                htmlFor="class-speed"
+                error={createTouched ? createErrors.speed : undefined}
+              >
+                <input
+                  id="class-speed"
+                  type="number"
+                  className={inputClassName}
+                  value={createForm.speed}
+                  onChange={(event) =>
+                    setCreateForm({ ...createForm, speed: event.target.value })
+                  }
+                />
+              </FormField>
+            </div>
+            <FormField
+              label="Ability progression"
+              hint="JSON"
+              error={createTouched ? createErrors.progressionJson : undefined}
+            >
+              <JsonEditor
+                value={createForm.progressionJson}
+                onChange={(value) => setCreateForm({ ...createForm, progressionJson: value })}
+                invalid={createTouched && Boolean(createErrors.progressionJson)}
+              />
+            </FormField>
+            <FormField
+              label="Trance variants"
+              hint="JSON"
+              error={createTouched ? createErrors.tranceJson : undefined}
+            >
+              <JsonEditor
+                value={createForm.tranceJson}
+                onChange={(value) => setCreateForm({ ...createForm, tranceJson: value })}
+                invalid={createTouched && Boolean(createErrors.tranceJson)}
+              />
+            </FormField>
           </div>
-          <ol className="mt-6 grid gap-4 text-sm text-slate-300">
-            <li className="flex gap-3">
-              <span className="text-aurora-cyan font-semibold">01</span>
-              <div>
-                <p className="text-white">Identity & Fantasy</p>
-                <p>Name, lore, visual identity, and role archetype.</p>
-              </div>
-            </li>
-            <li className="flex gap-3">
-              <span className="text-aurora-violet font-semibold">02</span>
-              <div>
-                <p className="text-white">Base Stats</p>
-                <p>HP/MP baselines, offense/defense, accuracy, and speed.</p>
-              </div>
-            </li>
-            <li className="flex gap-3">
-              <span className="text-aurora-magenta font-semibold">03</span>
-              <div>
-                <p className="text-white">Ability Progression</p>
-                <p>Unlock levels, temporary abilities, and milestone rewards.</p>
-              </div>
-            </li>
-            <li className="flex gap-3">
-              <span className="text-aurora-amber font-semibold">04</span>
-              <div>
-                <p className="text-white">Trance Variants</p>
-                <p>Trance duration, ability swaps, and visual overrides.</p>
-              </div>
-            </li>
-          </ol>
-        </div>
+          <WizardActions
+            message={createMessage}
+            onSaveDraft={() => handleCreateAction("Draft saved for class creation.")}
+            onPublish={() => handleCreateAction("Class creation draft queued for publish.")}
+          />
+        </WizardSection>
 
-        <div className="glass-panel rounded-3xl p-6">
-          <div className="flex items-center justify-between">
-            <h3 className="text-xl font-display">Class Update Flow</h3>
-            <span className="text-xs text-aurora-lime">Wizard Draft</span>
+        <WizardSection
+          title="Class Update"
+          badge="Wizard Draft"
+          description="Patch baselines, unlocks, and trance behavior for existing classes."
+        >
+          <div className="grid gap-4">
+            <FormField
+              label="Target class"
+              htmlFor="class-target"
+              error={updateTouched ? updateErrors.target : undefined}
+            >
+              <input
+                id="class-target"
+                className={inputClassName}
+                value={updateForm.target}
+                onChange={(event) => setUpdateForm({ ...updateForm, target: event.target.value })}
+                placeholder="Search by class name"
+              />
+            </FormField>
+            <div className="grid gap-4 md:grid-cols-2">
+              <FormField
+                label="Patch HP"
+                htmlFor="class-patch-hp"
+                error={updateTouched ? updateErrors.patchHp : undefined}
+              >
+                <input
+                  id="class-patch-hp"
+                  type="number"
+                  className={inputClassName}
+                  value={updateForm.patchHp}
+                  onChange={(event) =>
+                    setUpdateForm({ ...updateForm, patchHp: event.target.value })
+                  }
+                  placeholder="Optional"
+                />
+              </FormField>
+              <FormField
+                label="Patch MP"
+                htmlFor="class-patch-mp"
+                error={updateTouched ? updateErrors.patchMp : undefined}
+              >
+                <input
+                  id="class-patch-mp"
+                  type="number"
+                  className={inputClassName}
+                  value={updateForm.patchMp}
+                  onChange={(event) =>
+                    setUpdateForm({ ...updateForm, patchMp: event.target.value })
+                  }
+                  placeholder="Optional"
+                />
+              </FormField>
+            </div>
+            <FormField
+              label="Unlock progression"
+              hint="JSON"
+              error={updateTouched ? updateErrors.unlocksJson : undefined}
+            >
+              <JsonEditor
+                value={updateForm.unlocksJson}
+                onChange={(value) => setUpdateForm({ ...updateForm, unlocksJson: value })}
+                invalid={updateTouched && Boolean(updateErrors.unlocksJson)}
+              />
+            </FormField>
+            <FormField
+              label="Trance patch"
+              hint="JSON"
+              error={updateTouched ? updateErrors.tranceJson : undefined}
+            >
+              <JsonEditor
+                value={updateForm.tranceJson}
+                onChange={(value) => setUpdateForm({ ...updateForm, tranceJson: value })}
+                invalid={updateTouched && Boolean(updateErrors.tranceJson)}
+              />
+            </FormField>
           </div>
-          <ol className="mt-6 grid gap-4 text-sm text-slate-300">
-            <li className="flex gap-2">
-              <span className="text-aurora-cyan font-semibold">01</span>
-              <div>
-                <p className="text-white">Select Target</p>
-                <p>Search class name to load the current profile.</p>
-              </div>
-            </li>
-            <li className="flex gap-2">
-              <span className="text-aurora-violet font-semibold">02</span>
-              <div>
-                <p className="text-white">Patch Stats</p>
-                <p>Adjust baselines for HP/MP, offense/defense, and speed.</p>
-              </div>
-            </li>
-            <li className="flex gap-2">
-              <span className="text-aurora-magenta font-semibold">03</span>
-              <div>
-                <p className="text-white">Update Progression</p>
-                <p>Modify unlocks, temp skills, and trance configuration.</p>
-              </div>
-            </li>
-            <li className="flex gap-2">
-              <span className="text-aurora-amber font-semibold">04</span>
-              <div>
-                <p className="text-white">Publish</p>
-                <p>Review changes and save the updated class.</p>
-              </div>
-            </li>
-          </ol>
-        </div>
+          <WizardActions
+            message={updateMessage}
+            onSaveDraft={() => handleUpdateAction("Draft saved for class update.")}
+            onPublish={() => handleUpdateAction("Class update draft queued for publish.")}
+          />
+        </WizardSection>
       </section>
     </div>
   );

--- a/adventure-tools/src/pages/EnemiesPage.tsx
+++ b/adventure-tools/src/pages/EnemiesPage.tsx
@@ -1,4 +1,124 @@
+import { useState } from "react";
+import { FormField } from "../components/FormField";
+import { JsonEditor } from "../components/JsonEditor";
+import { WizardActions } from "../components/WizardActions";
+import { WizardSection } from "../components/WizardSection";
+
+const inputClassName =
+  "w-full rounded-2xl border border-white/10 bg-night-900/60 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-aurora-violet/70";
+
+const textareaClassName = `${inputClassName} min-h-[120px]`;
+
+const isValidJson = (value: string) => {
+  if (!value.trim()) {
+    return "JSON is required.";
+  }
+  try {
+    JSON.parse(value);
+    return "";
+  } catch {
+    return "Enter valid JSON.";
+  }
+};
+
+type EnemyCreateForm = {
+  name: string;
+  role: string;
+  difficulty: string;
+  description: string;
+  hp: string;
+  mp: string;
+  attack: string;
+  abilitiesJson: string;
+  resistancesJson: string;
+  dropsJson: string;
+};
+
+type EnemyUpdateForm = {
+  target: string;
+  patchHp: string;
+  patchAttack: string;
+  behaviorJson: string;
+  rewardsJson: string;
+};
+
+const initialCreateForm: EnemyCreateForm = {
+  name: "",
+  role: "",
+  difficulty: "",
+  description: "",
+  hp: "",
+  mp: "",
+  attack: "",
+  abilitiesJson: "{\n  \"rotation\": []\n}",
+  resistancesJson: "{\n  \"fire\": \"weak\",\n  \"ice\": \"neutral\"\n}",
+  dropsJson: "{\n  \"loot\": []\n}"
+};
+
+const initialUpdateForm: EnemyUpdateForm = {
+  target: "",
+  patchHp: "",
+  patchAttack: "",
+  behaviorJson: "{\n  \"rotation\": []\n}",
+  rewardsJson: "{\n  \"gil\": 0,\n  \"xp\": 0\n}"
+};
+
 export function EnemiesPage() {
+  const [createForm, setCreateForm] = useState(initialCreateForm);
+  const [updateForm, setUpdateForm] = useState(initialUpdateForm);
+  const [createTouched, setCreateTouched] = useState(false);
+  const [updateTouched, setUpdateTouched] = useState(false);
+  const [createMessage, setCreateMessage] = useState("");
+  const [updateMessage, setUpdateMessage] = useState("");
+
+  const createErrors = {
+    name: createForm.name.trim() ? "" : "Enemy name is required.",
+    role: createForm.role ? "" : "Select a role.",
+    difficulty: createForm.difficulty ? "" : "Select a difficulty tier.",
+    description: createForm.description.trim() ? "" : "Provide a short description.",
+    hp:
+      createForm.hp && Number(createForm.hp) > 0
+        ? ""
+        : "Enter a positive HP value.",
+    mp:
+      createForm.mp && Number(createForm.mp) >= 0
+        ? ""
+        : "Enter a non-negative MP value.",
+    attack:
+      createForm.attack && Number(createForm.attack) > 0
+        ? ""
+        : "Enter a positive attack value.",
+    abilitiesJson: isValidJson(createForm.abilitiesJson),
+    resistancesJson: isValidJson(createForm.resistancesJson),
+    dropsJson: isValidJson(createForm.dropsJson)
+  };
+
+  const updateErrors = {
+    target: updateForm.target.trim() ? "" : "Choose an enemy to update.",
+    patchHp:
+      !updateForm.patchHp || Number(updateForm.patchHp) > 0
+        ? ""
+        : "Enter a positive HP value.",
+    patchAttack:
+      !updateForm.patchAttack || Number(updateForm.patchAttack) > 0
+        ? ""
+        : "Enter a positive attack value.",
+    behaviorJson: isValidJson(updateForm.behaviorJson),
+    rewardsJson: isValidJson(updateForm.rewardsJson)
+  };
+
+  const handleCreateAction = (message: string) => {
+    setCreateTouched(true);
+    const hasErrors = Object.values(createErrors).some((error) => error);
+    setCreateMessage(hasErrors ? "Resolve validation errors before continuing." : message);
+  };
+
+  const handleUpdateAction = (message: string) => {
+    setUpdateTouched(true);
+    const hasErrors = Object.values(updateErrors).some((error) => error);
+    setUpdateMessage(hasErrors ? "Resolve validation errors before continuing." : message);
+  };
+
   return (
     <div className="space-y-8">
       <section className="glass-panel rounded-3xl p-6">
@@ -18,79 +138,245 @@ export function EnemiesPage() {
       </section>
 
       <section className="grid lg:grid-cols-2 gap-6">
-        <div className="glass-panel rounded-3xl p-6">
-          <div className="flex items-center justify-between">
-            <h3 className="text-xl font-display">Enemy Creation Flow</h3>
-            <span className="text-xs text-aurora-lime">Wizard Draft</span>
+        <WizardSection
+          title="Enemy Creation"
+          badge="Wizard Draft"
+          description="Capture the base identity, stats, and behavior blueprint for new enemies."
+        >
+          <div className="grid gap-4">
+            <FormField
+              label="Enemy name"
+              htmlFor="enemy-name"
+              error={createTouched ? createErrors.name : undefined}
+            >
+              <input
+                id="enemy-name"
+                className={inputClassName}
+                value={createForm.name}
+                onChange={(event) => setCreateForm({ ...createForm, name: event.target.value })}
+                placeholder="Clockwork Basilisk"
+              />
+            </FormField>
+            <div className="grid gap-4 md:grid-cols-2">
+              <FormField
+                label="Role"
+                htmlFor="enemy-role"
+                error={createTouched ? createErrors.role : undefined}
+              >
+                <select
+                  id="enemy-role"
+                  className={inputClassName}
+                  value={createForm.role}
+                  onChange={(event) => setCreateForm({ ...createForm, role: event.target.value })}
+                >
+                  <option value="">Select a role</option>
+                  <option value="bruiser">Bruiser</option>
+                  <option value="mage">Mage</option>
+                  <option value="support">Support</option>
+                  <option value="assassin">Assassin</option>
+                </select>
+              </FormField>
+              <FormField
+                label="Difficulty tier"
+                htmlFor="enemy-difficulty"
+                error={createTouched ? createErrors.difficulty : undefined}
+              >
+                <select
+                  id="enemy-difficulty"
+                  className={inputClassName}
+                  value={createForm.difficulty}
+                  onChange={(event) =>
+                    setCreateForm({ ...createForm, difficulty: event.target.value })
+                  }
+                >
+                  <option value="">Select tier</option>
+                  <option value="common">Common</option>
+                  <option value="elite">Elite</option>
+                  <option value="boss">Boss</option>
+                </select>
+              </FormField>
+            </div>
+            <FormField
+              label="Narrative description"
+              htmlFor="enemy-description"
+              error={createTouched ? createErrors.description : undefined}
+            >
+              <textarea
+                id="enemy-description"
+                className={textareaClassName}
+                value={createForm.description}
+                onChange={(event) =>
+                  setCreateForm({ ...createForm, description: event.target.value })
+                }
+                placeholder="Short lore hook used in the codex."
+              />
+            </FormField>
+            <div className="grid gap-4 md:grid-cols-3">
+              <FormField
+                label="Base HP"
+                htmlFor="enemy-hp"
+                error={createTouched ? createErrors.hp : undefined}
+              >
+                <input
+                  id="enemy-hp"
+                  type="number"
+                  className={inputClassName}
+                  value={createForm.hp}
+                  onChange={(event) => setCreateForm({ ...createForm, hp: event.target.value })}
+                />
+              </FormField>
+              <FormField
+                label="Base MP"
+                htmlFor="enemy-mp"
+                error={createTouched ? createErrors.mp : undefined}
+              >
+                <input
+                  id="enemy-mp"
+                  type="number"
+                  className={inputClassName}
+                  value={createForm.mp}
+                  onChange={(event) => setCreateForm({ ...createForm, mp: event.target.value })}
+                />
+              </FormField>
+              <FormField
+                label="Attack"
+                htmlFor="enemy-attack"
+                error={createTouched ? createErrors.attack : undefined}
+              >
+                <input
+                  id="enemy-attack"
+                  type="number"
+                  className={inputClassName}
+                  value={createForm.attack}
+                  onChange={(event) =>
+                    setCreateForm({ ...createForm, attack: event.target.value })
+                  }
+                />
+              </FormField>
+            </div>
+            <FormField
+              label="Ability rotation"
+              hint="JSON"
+              error={createTouched ? createErrors.abilitiesJson : undefined}
+            >
+              <JsonEditor
+                value={createForm.abilitiesJson}
+                onChange={(value) => setCreateForm({ ...createForm, abilitiesJson: value })}
+                invalid={createTouched && Boolean(createErrors.abilitiesJson)}
+              />
+            </FormField>
+            <FormField
+              label="Resistances map"
+              hint="JSON"
+              error={createTouched ? createErrors.resistancesJson : undefined}
+            >
+              <JsonEditor
+                value={createForm.resistancesJson}
+                onChange={(value) => setCreateForm({ ...createForm, resistancesJson: value })}
+                invalid={createTouched && Boolean(createErrors.resistancesJson)}
+              />
+            </FormField>
+            <FormField
+              label="Drop table"
+              hint="JSON"
+              error={createTouched ? createErrors.dropsJson : undefined}
+            >
+              <JsonEditor
+                value={createForm.dropsJson}
+                onChange={(value) => setCreateForm({ ...createForm, dropsJson: value })}
+                invalid={createTouched && Boolean(createErrors.dropsJson)}
+              />
+            </FormField>
           </div>
-          <ol className="mt-6 grid gap-4 text-sm text-slate-300">
-            <li className="flex gap-3">
-              <span className="text-aurora-cyan font-semibold">01</span>
-              <div>
-                <p className="text-white">Base Identity</p>
-                <p>Name, role, lore description, images, difficulty tier.</p>
-              </div>
-            </li>
-            <li className="flex gap-3">
-              <span className="text-aurora-violet font-semibold">02</span>
-              <div>
-                <p className="text-white">Stat Blueprint</p>
-                <p>HP/MP, attack/magic, defenses, accuracy, evasion, speed/ATB.</p>
-              </div>
-            </li>
-            <li className="flex gap-3">
-              <span className="text-aurora-magenta font-semibold">03</span>
-              <div>
-                <p className="text-white">Ability Rotation</p>
-                <p>Assign abilities, weights, scaling stats, healing thresholds.</p>
-              </div>
-            </li>
-            <li className="flex gap-3">
-              <span className="text-aurora-amber font-semibold">04</span>
-              <div>
-                <p className="text-white">Resistances & Drops</p>
-                <p>Element relations, loot table, gil/xp reward defaults.</p>
-              </div>
-            </li>
-          </ol>
-        </div>
+          <WizardActions
+            message={createMessage}
+            onSaveDraft={() => handleCreateAction("Draft saved for enemy creation.")}
+            onPublish={() => handleCreateAction("Enemy creation draft queued for publish.")}
+          />
+        </WizardSection>
 
-        <div className="glass-panel rounded-3xl p-6">
-          <div className="flex items-center justify-between">
-            <h3 className="text-xl font-display">Enemy Update Flow</h3>
-            <span className="text-xs text-aurora-lime">Wizard Draft</span>
+        <WizardSection
+          title="Enemy Update"
+          badge="Wizard Draft"
+          description="Locate an existing enemy and patch stats, behaviors, and rewards."
+        >
+          <div className="grid gap-4">
+            <FormField
+              label="Target enemy"
+              htmlFor="enemy-target"
+              error={updateTouched ? updateErrors.target : undefined}
+            >
+              <input
+                id="enemy-target"
+                className={inputClassName}
+                value={updateForm.target}
+                onChange={(event) => setUpdateForm({ ...updateForm, target: event.target.value })}
+                placeholder="Search by name or ID"
+              />
+            </FormField>
+            <div className="grid gap-4 md:grid-cols-2">
+              <FormField
+                label="Patch HP"
+                htmlFor="enemy-patch-hp"
+                error={updateTouched ? updateErrors.patchHp : undefined}
+              >
+                <input
+                  id="enemy-patch-hp"
+                  type="number"
+                  className={inputClassName}
+                  value={updateForm.patchHp}
+                  onChange={(event) =>
+                    setUpdateForm({ ...updateForm, patchHp: event.target.value })
+                  }
+                  placeholder="Leave empty to keep current"
+                />
+              </FormField>
+              <FormField
+                label="Patch Attack"
+                htmlFor="enemy-patch-attack"
+                error={updateTouched ? updateErrors.patchAttack : undefined}
+              >
+                <input
+                  id="enemy-patch-attack"
+                  type="number"
+                  className={inputClassName}
+                  value={updateForm.patchAttack}
+                  onChange={(event) =>
+                    setUpdateForm({ ...updateForm, patchAttack: event.target.value })
+                  }
+                  placeholder="Leave empty to keep current"
+                />
+              </FormField>
+            </div>
+            <FormField
+              label="Behavior overrides"
+              hint="JSON"
+              error={updateTouched ? updateErrors.behaviorJson : undefined}
+            >
+              <JsonEditor
+                value={updateForm.behaviorJson}
+                onChange={(value) => setUpdateForm({ ...updateForm, behaviorJson: value })}
+                invalid={updateTouched && Boolean(updateErrors.behaviorJson)}
+              />
+            </FormField>
+            <FormField
+              label="Rewards delta"
+              hint="JSON"
+              error={updateTouched ? updateErrors.rewardsJson : undefined}
+            >
+              <JsonEditor
+                value={updateForm.rewardsJson}
+                onChange={(value) => setUpdateForm({ ...updateForm, rewardsJson: value })}
+                invalid={updateTouched && Boolean(updateErrors.rewardsJson)}
+              />
+            </FormField>
           </div>
-          <ol className="mt-6 grid gap-4 text-sm text-slate-300">
-            <li className="flex gap-2">
-              <span className="text-aurora-cyan font-semibold">01</span>
-              <div>
-                <p className="text-white">Select Target</p>
-                <p>Search by name, role, or internal ID to load a record.</p>
-              </div>
-            </li>
-            <li className="flex gap-2">
-              <span className="text-aurora-violet font-semibold">02</span>
-              <div>
-                <p className="text-white">Patch Stats</p>
-                <p>Adjust HP/MP, offense/defense, speed, and reward outputs.</p>
-              </div>
-            </li>
-            <li className="flex gap-2">
-              <span className="text-aurora-magenta font-semibold">03</span>
-              <div>
-                <p className="text-white">Revise Behaviors</p>
-                <p>Update ability weights, resistances, and drop tables.</p>
-              </div>
-            </li>
-            <li className="flex gap-2">
-              <span className="text-aurora-amber font-semibold">04</span>
-              <div>
-                <p className="text-white">Publish</p>
-                <p>Review deltas and push updates to the content table.</p>
-              </div>
-            </li>
-          </ol>
-        </div>
+          <WizardActions
+            message={updateMessage}
+            onSaveDraft={() => handleUpdateAction("Draft saved for enemy update.")}
+            onPublish={() => handleUpdateAction("Enemy update draft queued for publish.")}
+          />
+        </WizardSection>
       </section>
     </div>
   );

--- a/adventure-tools/src/pages/ItemsPage.tsx
+++ b/adventure-tools/src/pages/ItemsPage.tsx
@@ -1,4 +1,118 @@
+import { useState } from "react";
+import { FormField } from "../components/FormField";
+import { JsonEditor } from "../components/JsonEditor";
+import { WizardActions } from "../components/WizardActions";
+import { WizardSection } from "../components/WizardSection";
+
+const inputClassName =
+  "w-full rounded-2xl border border-white/10 bg-night-900/60 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-aurora-violet/70";
+
+const textareaClassName = `${inputClassName} min-h-[120px]`;
+
+const isValidJson = (value: string) => {
+  if (!value.trim()) {
+    return "JSON is required.";
+  }
+  try {
+    JSON.parse(value);
+    return "";
+  } catch {
+    return "Enter valid JSON.";
+  }
+};
+
+type ItemCreateForm = {
+  name: string;
+  type: string;
+  rarity: string;
+  iconUrl: string;
+  description: string;
+  effectJson: string;
+  price: string;
+  vendorStock: string;
+  distributionJson: string;
+};
+
+type ItemUpdateForm = {
+  target: string;
+  price: string;
+  cooldown: string;
+  effectJson: string;
+  placementJson: string;
+};
+
+const initialCreateForm: ItemCreateForm = {
+  name: "",
+  type: "",
+  rarity: "",
+  iconUrl: "",
+  description: "",
+  effectJson: "{\n  \"effects\": []\n}",
+  price: "",
+  vendorStock: "",
+  distributionJson: "{\n  \"vendors\": [],\n  \"drops\": []\n}"
+};
+
+const initialUpdateForm: ItemUpdateForm = {
+  target: "",
+  price: "",
+  cooldown: "",
+  effectJson: "{\n  \"effects\": []\n}",
+  placementJson: "{\n  \"vendors\": [],\n  \"chests\": []\n}"
+};
+
 export function ItemsPage() {
+  const [createForm, setCreateForm] = useState(initialCreateForm);
+  const [updateForm, setUpdateForm] = useState(initialUpdateForm);
+  const [createTouched, setCreateTouched] = useState(false);
+  const [updateTouched, setUpdateTouched] = useState(false);
+  const [createMessage, setCreateMessage] = useState("");
+  const [updateMessage, setUpdateMessage] = useState("");
+
+  const createErrors = {
+    name: createForm.name.trim() ? "" : "Item name is required.",
+    type: createForm.type ? "" : "Select an item type.",
+    rarity: createForm.rarity ? "" : "Select a rarity tier.",
+    iconUrl: createForm.iconUrl.trim() ? "" : "Provide an icon URL.",
+    description: createForm.description.trim() ? "" : "Add a short description.",
+    effectJson: isValidJson(createForm.effectJson),
+    price:
+      createForm.price && Number(createForm.price) >= 0
+        ? ""
+        : "Enter a price value.",
+    vendorStock:
+      createForm.vendorStock && Number(createForm.vendorStock) >= 0
+        ? ""
+        : "Enter vendor stock quantity.",
+    distributionJson: isValidJson(createForm.distributionJson)
+  };
+
+  const updateErrors = {
+    target: updateForm.target.trim() ? "" : "Select an item to update.",
+    price:
+      !updateForm.price || Number(updateForm.price) >= 0
+        ? ""
+        : "Enter a valid price.",
+    cooldown:
+      !updateForm.cooldown || Number(updateForm.cooldown) >= 0
+        ? ""
+        : "Enter a cooldown value.",
+    effectJson: isValidJson(updateForm.effectJson),
+    placementJson: isValidJson(updateForm.placementJson)
+  };
+
+  const handleCreateAction = (message: string) => {
+    setCreateTouched(true);
+    const hasErrors = Object.values(createErrors).some((error) => error);
+    setCreateMessage(hasErrors ? "Resolve validation errors before continuing." : message);
+  };
+
+  const handleUpdateAction = (message: string) => {
+    setUpdateTouched(true);
+    const hasErrors = Object.values(updateErrors).some((error) => error);
+    setUpdateMessage(hasErrors ? "Resolve validation errors before continuing." : message);
+  };
+
   return (
     <div className="space-y-8">
       <section className="glass-panel rounded-3xl p-6">
@@ -18,79 +132,256 @@ export function ItemsPage() {
       </section>
 
       <section className="grid lg:grid-cols-2 gap-6">
-        <div className="glass-panel rounded-3xl p-6">
-          <div className="flex items-center justify-between">
-            <h3 className="text-xl font-display">Item Creation Flow</h3>
-            <span className="text-xs text-aurora-lime">Wizard Draft</span>
+        <WizardSection
+          title="Item Creation"
+          badge="Wizard Draft"
+          description="Define item identity, gameplay effects, and distribution defaults."
+        >
+          <div className="grid gap-4">
+            <FormField
+              label="Item name"
+              htmlFor="item-name"
+              error={createTouched ? createErrors.name : undefined}
+            >
+              <input
+                id="item-name"
+                className={inputClassName}
+                value={createForm.name}
+                onChange={(event) => setCreateForm({ ...createForm, name: event.target.value })}
+                placeholder="Phoenix Tonic"
+              />
+            </FormField>
+            <div className="grid gap-4 md:grid-cols-2">
+              <FormField
+                label="Item type"
+                htmlFor="item-type"
+                error={createTouched ? createErrors.type : undefined}
+              >
+                <select
+                  id="item-type"
+                  className={inputClassName}
+                  value={createForm.type}
+                  onChange={(event) => setCreateForm({ ...createForm, type: event.target.value })}
+                >
+                  <option value="">Select type</option>
+                  <option value="consumable">Consumable</option>
+                  <option value="weapon">Weapon</option>
+                  <option value="armor">Armor</option>
+                  <option value="key-item">Key Item</option>
+                </select>
+              </FormField>
+              <FormField
+                label="Rarity tier"
+                htmlFor="item-rarity"
+                error={createTouched ? createErrors.rarity : undefined}
+              >
+                <select
+                  id="item-rarity"
+                  className={inputClassName}
+                  value={createForm.rarity}
+                  onChange={(event) =>
+                    setCreateForm({ ...createForm, rarity: event.target.value })
+                  }
+                >
+                  <option value="">Select tier</option>
+                  <option value="common">Common</option>
+                  <option value="rare">Rare</option>
+                  <option value="legendary">Legendary</option>
+                </select>
+              </FormField>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              <FormField
+                label="Icon URL"
+                htmlFor="item-icon"
+                error={createTouched ? createErrors.iconUrl : undefined}
+              >
+                <input
+                  id="item-icon"
+                  className={inputClassName}
+                  value={createForm.iconUrl}
+                  onChange={(event) =>
+                    setCreateForm({ ...createForm, iconUrl: event.target.value })
+                  }
+                  placeholder="https://"
+                />
+              </FormField>
+              <FormField
+                label="Base price"
+                htmlFor="item-price"
+                error={createTouched ? createErrors.price : undefined}
+              >
+                <input
+                  id="item-price"
+                  type="number"
+                  className={inputClassName}
+                  value={createForm.price}
+                  onChange={(event) => setCreateForm({ ...createForm, price: event.target.value })}
+                />
+              </FormField>
+            </div>
+            <FormField
+              label="Description"
+              htmlFor="item-description"
+              error={createTouched ? createErrors.description : undefined}
+            >
+              <textarea
+                id="item-description"
+                className={textareaClassName}
+                value={createForm.description}
+                onChange={(event) =>
+                  setCreateForm({ ...createForm, description: event.target.value })
+                }
+                placeholder="Short flavor copy for the codex."
+              />
+            </FormField>
+            <FormField
+              label="Effect payload"
+              hint="JSON"
+              error={createTouched ? createErrors.effectJson : undefined}
+            >
+              <JsonEditor
+                value={createForm.effectJson}
+                onChange={(value) => setCreateForm({ ...createForm, effectJson: value })}
+                invalid={createTouched && Boolean(createErrors.effectJson)}
+              />
+            </FormField>
+            <div className="grid gap-4 md:grid-cols-2">
+              <FormField
+                label="Vendor stock"
+                htmlFor="item-stock"
+                error={createTouched ? createErrors.vendorStock : undefined}
+              >
+                <input
+                  id="item-stock"
+                  type="number"
+                  className={inputClassName}
+                  value={createForm.vendorStock}
+                  onChange={(event) =>
+                    setCreateForm({ ...createForm, vendorStock: event.target.value })
+                  }
+                />
+              </FormField>
+              <FormField label="Default vendor" htmlFor="item-vendor">
+                <select
+                  id="item-vendor"
+                  className={inputClassName}
+                  value={createForm.distributionJson}
+                  onChange={(event) =>
+                    setCreateForm({ ...createForm, distributionJson: event.target.value })
+                  }
+                >
+                  <option value={createForm.distributionJson}>Use distribution JSON</option>
+                  <option
+                    value={`{\n  \"vendors\": [\"starter-bazaar\"],\n  \"drops\": []\n}`}
+                  >
+                    Starter Bazaar
+                  </option>
+                  <option value={`{\n  \"vendors\": [\"sky-dock\"],\n  \"drops\": []\n}`}>
+                    Sky Dock
+                  </option>
+                </select>
+              </FormField>
+            </div>
+            <FormField
+              label="Distribution overrides"
+              hint="JSON"
+              error={createTouched ? createErrors.distributionJson : undefined}
+            >
+              <JsonEditor
+                value={createForm.distributionJson}
+                onChange={(value) => setCreateForm({ ...createForm, distributionJson: value })}
+                invalid={createTouched && Boolean(createErrors.distributionJson)}
+              />
+            </FormField>
           </div>
-          <ol className="mt-6 grid gap-4 text-sm text-slate-300">
-            <li className="flex gap-3">
-              <span className="text-aurora-cyan font-semibold">01</span>
-              <div>
-                <p className="text-white">Identity & Art</p>
-                <p>Name, item type, rarity tier, icon, and flavor description.</p>
-              </div>
-            </li>
-            <li className="flex gap-3">
-              <span className="text-aurora-violet font-semibold">02</span>
-              <div>
-                <p className="text-white">Effect Payload</p>
-                <p>JSON effects, target type, usage limits, and cooldown behavior.</p>
-              </div>
-            </li>
-            <li className="flex gap-3">
-              <span className="text-aurora-magenta font-semibold">03</span>
-              <div>
-                <p className="text-white">Economy</p>
-                <p>Price bands, vendor stock defaults, and sell ratios.</p>
-              </div>
-            </li>
-            <li className="flex gap-3">
-              <span className="text-aurora-amber font-semibold">04</span>
-              <div>
-                <p className="text-white">Distribution</p>
-                <p>Attach to vendors, enemy drop tables, and loot chests.</p>
-              </div>
-            </li>
-          </ol>
-        </div>
+          <WizardActions
+            message={createMessage}
+            onSaveDraft={() => handleCreateAction("Draft saved for item creation.")}
+            onPublish={() => handleCreateAction("Item creation draft queued for publish.")}
+          />
+        </WizardSection>
 
-        <div className="glass-panel rounded-3xl p-6">
-          <div className="flex items-center justify-between">
-            <h3 className="text-xl font-display">Item Update Flow</h3>
-            <span className="text-xs text-aurora-lime">Wizard Draft</span>
+        <WizardSection
+          title="Item Update"
+          badge="Wizard Draft"
+          description="Patch live items with updated effects, price bands, and placement."
+        >
+          <div className="grid gap-4">
+            <FormField
+              label="Target item"
+              htmlFor="item-target"
+              error={updateTouched ? updateErrors.target : undefined}
+            >
+              <input
+                id="item-target"
+                className={inputClassName}
+                value={updateForm.target}
+                onChange={(event) => setUpdateForm({ ...updateForm, target: event.target.value })}
+                placeholder="Search by name or ID"
+              />
+            </FormField>
+            <div className="grid gap-4 md:grid-cols-2">
+              <FormField
+                label="New price"
+                htmlFor="item-update-price"
+                error={updateTouched ? updateErrors.price : undefined}
+              >
+                <input
+                  id="item-update-price"
+                  type="number"
+                  className={inputClassName}
+                  value={updateForm.price}
+                  onChange={(event) => setUpdateForm({ ...updateForm, price: event.target.value })}
+                  placeholder="Leave empty to keep"
+                />
+              </FormField>
+              <FormField
+                label="Cooldown (turns)"
+                htmlFor="item-update-cooldown"
+                error={updateTouched ? updateErrors.cooldown : undefined}
+              >
+                <input
+                  id="item-update-cooldown"
+                  type="number"
+                  className={inputClassName}
+                  value={updateForm.cooldown}
+                  onChange={(event) =>
+                    setUpdateForm({ ...updateForm, cooldown: event.target.value })
+                  }
+                  placeholder="Optional"
+                />
+              </FormField>
+            </div>
+            <FormField
+              label="Effect patch"
+              hint="JSON"
+              error={updateTouched ? updateErrors.effectJson : undefined}
+            >
+              <JsonEditor
+                value={updateForm.effectJson}
+                onChange={(value) => setUpdateForm({ ...updateForm, effectJson: value })}
+                invalid={updateTouched && Boolean(updateErrors.effectJson)}
+              />
+            </FormField>
+            <FormField
+              label="Placement adjustments"
+              hint="JSON"
+              error={updateTouched ? updateErrors.placementJson : undefined}
+            >
+              <JsonEditor
+                value={updateForm.placementJson}
+                onChange={(value) => setUpdateForm({ ...updateForm, placementJson: value })}
+                invalid={updateTouched && Boolean(updateErrors.placementJson)}
+              />
+            </FormField>
           </div>
-          <ol className="mt-6 grid gap-4 text-sm text-slate-300">
-            <li className="flex gap-2">
-              <span className="text-aurora-cyan font-semibold">01</span>
-              <div>
-                <p className="text-white">Select Target</p>
-                <p>Search by name or item type to load an entry.</p>
-              </div>
-            </li>
-            <li className="flex gap-2">
-              <span className="text-aurora-violet font-semibold">02</span>
-              <div>
-                <p className="text-white">Patch Core Data</p>
-                <p>Update item effect payload, usage limit, and pricing.</p>
-              </div>
-            </li>
-            <li className="flex gap-2">
-              <span className="text-aurora-magenta font-semibold">03</span>
-              <div>
-                <p className="text-white">Revise Placement</p>
-                <p>Adjust vendor availability and drop table placement.</p>
-              </div>
-            </li>
-            <li className="flex gap-2">
-              <span className="text-aurora-amber font-semibold">04</span>
-              <div>
-                <p className="text-white">Publish</p>
-                <p>Review changes and save to the live item catalog.</p>
-              </div>
-            </li>
-          </ol>
-        </div>
+          <WizardActions
+            message={updateMessage}
+            onSaveDraft={() => handleUpdateAction("Draft saved for item update.")}
+            onPublish={() => handleUpdateAction("Item update draft queued for publish.")}
+          />
+        </WizardSection>
       </section>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Replace static instructional lists with real editable wizard flows for content authoring to enable creation and patching of records.
- Standardize UI and interactions across authoring pages by extracting shared form primitives and action bars.
- Provide local form state and immediate validation feedback so drafts can be saved or published with clearer errors.

### Description
- Introduces shared components under `adventure-tools/src/components/`: `WizardSection`, `FormField`, `JsonEditor`, and `WizardActions` to centralize layout and actions.
- Replaces static content on `EnemiesPage.tsx`, `ItemsPage.tsx`, `ClassesPage.tsx`, and `AbilitiesPage.tsx` with interactive forms using `useState`, JSON editors, and `isValidJson` validation helpers.
- Adds per-wizard validation state, user-facing error messages, and consistent `Save draft` / `Publish` actions via the `WizardActions` component.
- Fixes JSX quoting for inline JSON option values in `ItemsPage.tsx` and adds small schema fields (`style`, `trigger`) to relevant forms for completeness.

### Testing
- Ran `npm install` in `adventure-tools` and the dependencies installed successfully.
- Started the dev server with `npm run dev` and Vite reported ready after resolving a JSX parsing error introduced by raw JSON in an attribute.
- Automated UI capture via Playwright: Chromium runs failed due to a browser crash/segfault, while a Firefox run succeeded and produced a screenshot at `artifacts/enemies-form.png`.
- Changes were committed locally and the updated files compile and serve under the dev server after the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bafff0e988328a8cbd74be5b74e5d)