### PR TITLE
Fix uninitialized `pid` in battle start (Beast Master)

### DIFF
--- a/game/battle_system.py
+++ b/game/battle_system.py
@@ -1262,22 +1262,10 @@ class BattleSystem(commands.Cog):
             player_label += f" (Lv {player_level})"
         eb.add_field(name=player_label, value=stats_text, inline=False)
 
-        active_beast = getattr(session, "active_beasts", {}).get(pid)
+        pid = session.current_turn or player_id
+        active_beast = getattr(session, "active_beasts", {}).get(pid) if session else None
         if active_beast:
             beast_state = self._get_beast_state(session.session_id, pid, active_beast["beast_id"])
-            if beast_state:
-                beast_stats = self._calculate_beast_stats(beast_state, beast_state["level"])
-                beast_hp = beast_state.get("current_hp", beast_stats.get("hp", 0))
-                beast_mp = beast_state.get("current_mp", beast_stats.get("mp", 0))
-                beast_text = f"❤️ HP: {create_health_bar(beast_hp, beast_stats.get('max_hp', beast_hp))}"
-                if beast_stats.get("max_mp"):
-                    beast_text += f"\n💠 MP: {create_health_bar(beast_mp, beast_stats.get('max_mp', beast_mp))}"
-                beast_text += f"\n⚔️ ATK: {beast_stats.get('attack', 0)}\n🛡️ DEF: {beast_stats.get('defense', 0)}"
-                eb.add_field(name=f"Beast: {beast_state['name']} (Lv {beast_state['level']})", value=beast_text, inline=False)
-
-        active_beast = getattr(session, "active_beasts", {}).get(player_id) if session else None
-        if active_beast:
-            beast_state = self._get_beast_state(session.session_id, player_id, active_beast["beast_id"])
             if beast_state:
                 beast_stats = self._calculate_beast_stats(beast_state, beast_state["level"])
                 beast_hp = beast_state.get("current_hp", beast_stats.get("hp", 0))
@@ -1294,7 +1282,6 @@ class BattleSystem(commands.Cog):
         if enemy.get("image_url"):
             eb.set_image(url=enemy["image_url"] + f"?t={int(time.time())}")
 
-        pid    = session.current_turn
         trance = getattr(session, "trance_states", {}).get(pid)
         if trance:
             bar   = create_progress_bar(trance["remaining"], trance["max"], length=6)


### PR DESCRIPTION
### Motivation
- Starting a battle could reference an uninitialized `pid` when rendering the battle start embed for Beast Master players, causing errors.
- The code contained duplicate logic for displaying an active beast which used different player id lookups.
- The intent is to reliably show the active beast for the correct player while avoiding unbound name errors.

### Description
- Initialize `pid` with `session.current_turn or player_id` and use it to lookup `active_beasts` and related state.
- Update the `_get_beast_state` call to pass the resolved `pid` instead of `player_id` to fetch the correct beast.
- Remove the duplicated active-beast display block and the redundant later `pid = session.current_turn` assignment.

### Testing
- No automated tests were run on this change.
- The change is limited to `game/battle_system.py` and fixes an immediate unbound name/runtime issue when starting battles.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bb875d81c8328bad01dc9ad121ca9)