### PR TITLE
Fix missing 'and' in inventory item target check

### DIFF
--- a/game/inventory_shop.py
+++ b/game/inventory_shop.py
@@ -510,7 +510,7 @@ class InventoryShop(commands.Cog):
             effect = json.loads(item_row["effect"]) if item_row.get("effect") else {}
             if (
                 prompt_for_target
-                session.current_enemy
+                and session.current_enemy
                 and self._item_has_healing_effect(effect)
                 and target == "player"
                 and getattr(session, "active_beasts", None)


### PR DESCRIPTION
### Motivation

- A recent edit introduced a syntax error in the use-item logic that caused the bot to fail during module import/compilation.
- The broken condition also prevented the flow that prompts players to choose a target when using healing items while an enemy is present.

### Description

- Add the missing `and` between `prompt_for_target` and `session.current_enemy` in `game/inventory_shop.py` to fix the boolean expression.
- This change resolves the `SyntaxError` and restores the intended prompt-for-target behavior for healing items when an active beast and enemy are present.

### Testing

- `python -m py_compile game/inventory_shop.py` previously failed with a `SyntaxError` before the fix.
- `python -m py_compile game/inventory_shop.py` succeeded after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bca7ff82083289f9c9c001b4efa60)