### PR TITLE
Fix abilities seed mp_cost handling

### DIFF
--- a/database/database_setup.py
+++ b/database/database_setup.py
@@ -1863,15 +1863,38 @@ def insert_element_oppositions(cur):
 
 def insert_abilities(cur):
     logger.info("Checking abilities seed data…")
+    normalized_abilities = []
+    for ability in MERGED_ABILITIES:
+        if len(ability) == 13:
+            ability = (
+                ability[0],
+                ability[1],
+                ability[2],
+                ability[3],
+                ability[4],
+                0,
+                ability[5],
+                ability[6],
+                ability[7],
+                ability[8],
+                ability[9],
+                ability[10],
+                ability[11],
+                ability[12],
+            )
+        if len(ability) != 14:
+            logger.warning("Skipping abilities seed row with unexpected shape: %s", ability)
+            continue
+        normalized_abilities.append(ability)
     cur.executemany(
         """
         INSERT IGNORE INTO abilities
-          (ability_id, ability_name, description, effect, cooldown, icon_url,
+          (ability_id, ability_name, description, effect, cooldown, mp_cost, icon_url,
            target_type, special_effect, element_id, status_effect_id,
            status_duration, created_at, scaling_stat)
-        VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+        VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
         """,
-        MERGED_ABILITIES
+        normalized_abilities
     )
     cur.executemany(
         """


### PR DESCRIPTION
### Motivation
- The `abilities` seed data contained a mix of 13- and 14-field tuples while the `abilities` table schema includes an `mp_cost` column, causing shape mismatches during seeding.
- Missing `mp_cost` values would break `executemany` parameter binding or leave incorrect data in the database. 
- The change is intended to normalize seed rows so all abilities insert with the correct number of fields.

### Description
- Add a normalization step that iterates `MERGED_ABILITIES`, injecting a default `mp_cost = 0` for tuples of length 13 and collecting normalized rows in `normalized_abilities`.
- Skip and log a warning for any seed rows that do not become 14-field tuples after normalization using `logger.warning`.
- Update the first `INSERT IGNORE INTO abilities` call to include the `mp_cost` column in the column list and use `normalized_abilities` as the data source.
- Leave the existing eidolon abilities insertion (`MERGED_EIDOLON_ABILITY_DEFS`) unchanged since those already include `mp_cost`.

### Testing
- Ran a static inspection script (`python - <<'PY'`) that parsed `MERGED_ABILITIES` and reported 131 total ability rows with 32 rows missing the `mp_cost` field, confirming the normalization target.
- Applied the patch and the file updated successfully (`database/database_setup.py` was changed and committed).
- No database seeding or runtime integration tests were executed as part of this change.
- No automated unit test suite was run for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bd28e315483289842346fd98174cc)