### PR TITLE
Fix crash on Beast Master back button in battle embed

### DIFF
--- a/game/battle_system.py
+++ b/game/battle_system.py
@@ -1275,6 +1275,7 @@ class BattleSystem(commands.Cog):
         eb.add_field(name=player_label, value=stats_text, inline=False)
 
         pid = session.current_turn or player_id
+        pid = player_id
         active_beast = getattr(session, "active_beasts", {}).get(pid) if session else None
         if active_beast:
             beast_state = self._get_beast_state(session.session_id, pid, active_beast["beast_id"])
@@ -1399,6 +1400,7 @@ class BattleSystem(commands.Cog):
             player_label += f" (Lv {player_level})"
         eb.add_field(name=player_label, value=stats_text, inline=False)
 
+        pid = player_id
         active_beast = getattr(session, "active_beasts", {}).get(pid) if session else None
         if active_beast:
             beast_state = self._get_beast_state(session.session_id, pid, active_beast["beast_id"])


### PR DESCRIPTION
### Motivation
- Returning from the Beast Master skill/menu could crash when `update_battle_embed` attempted to read beast data without a valid player id.
- The crash manifested as an `UnboundLocalError` (or incorrect `pid`) when the back button was pressed in the beast menu.

### Description
- Initialize `pid` from the `player_id` argument early in `update_battle_embed` to ensure the correct player context is used when reading `session.active_beasts`.
- Change applied in `game/battle_system.py` by inserting `pid = player_id` before accessing `active_beast`.

### Testing
- No automated tests were run for this change.
- Local validation consisted of reviewing the updated `update_battle_embed` flow to ensure `pid` is defined before use.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c18ef3540832892c3a8246fbde3b5)