### PR TITLE
Allow revive items/abilities to revive tamed beasts and Eidolons in battle

### DIFF
--- a/game/embed_manager.py
+++ b/game/embed_manager.py
@@ -620,7 +620,11 @@ class EmbedManager(commands.Cog):
         view = View(timeout=None)
         for item in inventory_items:
             tgt = item.get("target_type", "any")
-            usable = (tgt in ["self", "enemy", "any"]) if allowed_context == "battle" else (tgt in ["self", "ally", "any"])
+            usable = (
+                tgt in ["self", "enemy", "any", "ally"]
+                if allowed_context == "battle"
+                else tgt in ["self", "ally", "any"]
+            )
             note = "" if usable else " (Not usable here)"
             inv_text += f"**{item['item_name']}**: {item.get('description','')} {note}\nQuantity: {item.get('quantity',0)}\n\n"
             btn = Button(

--- a/utils/ability_engine.py
+++ b/utils/ability_engine.py
@@ -463,6 +463,11 @@ class AbilityEngine:
                 logs.append(f"{name} deals {dmg} damage.")
                 result = AbilityResult(type="damage", amount=dmg, logs=logs)
 
+            if result is None and "heal" in effect_data:
+                amt = int(effect_data.get("heal", 0))
+                logs.append(f"{name} restores {amt} HP.")
+                result = AbilityResult(type="heal", amount=amt, logs=logs)
+
             if result is None and "heal_current_pct" in effect_data:
                 pct = effect_data["heal_current_pct"]
                 amt = int(target["hp"] * pct)


### PR DESCRIPTION
### Motivation

- Players should be able to use revive items (e.g. Phoenix Down) during battles to revive their tamed beasts or fallen Eidolons, not only out-of-battle allies. 
- Abilities and item JSON that include a `heal` or `revive` key should behave consistently and be usable as in-battle revive/heal effects. 
- Prevent KO companions from acting while keeping them targetable for revival so revive flows are meaningful. 

### Description

- Updated the item UI so `ally`/revive items appear usable in-battle by allowing `ally` target types in `EmbedManager.send_use_item_embed`. 
- Extended inventory/item flow in `InventoryShop` (`display_use_item_menu`, `process_use_item`, `display_use_item_target_menu`) to: include revive items in battle, present dynamic target lists (player, active beast, KO beasts, `eidolon`), and handle reviving a KO beast or re-enabling a fallen Eidolon. 
- Taught the ability engine to treat a JSON `"heal"` field as a healing result by adding support in `AbilityEngine.resolve`, and expanded `BattleSystem._is_healing_ability` to consider `heal` and `revive` keys. 
- Added in-battle revive handling in `BattleSystem.handle_skill_use` to revive a player’s KO beast or to restore a fallen Eidolon summon, and tightened beast lifecycle checks so KO beasts cannot act but remain revivable. 

### Testing

- No automated tests were run on these changes. 
- Changes were committed to the working branch for manual verification and further test coverage to be added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c284f52848328971adadc63503e52)