### PR TITLE
Add Beast Mend ability and heal-all-beasts logic for Beast Master

### DIFF
--- a/database/database_setup.py
+++ b/database/database_setup.py
@@ -241,6 +241,7 @@ MERGED_ABILITIES: List[Tuple] = [
     (204, 'Inferno', 'Engulf the enemy in infernal flames.', '{"base_damage": 275}', 0, 50, None, 'enemy', None, 1, 6, 10, '2025-12-20 23:44:43', 'magic_power'),
     (205, 'Cold Snap', 'Freeze Enemies while causing damage.', '{"base_damage": 275}', 0, 50, None, 'enemy', None, 2, 7, 10, '2025-12-20 23:44:43', 'magic_power'),
     (206, 'Storm Tempest', 'Stun your foe with a devistating storm.', '{"base_damage": 275}', 0, 50, None, 'enemy', None, 6, 5, 10, '2025-12-20 23:44:43', 'magic_power'),
+    (207, 'Beast Mend', 'Restore all tamed beasts by a percentage of their maximum health.', '{"heal_all_beasts_pct": 1.0}', 3, 20, '🐾❤️', 'self', None, None, None, None, '2025-12-20 23:44:43', 'magic_power'),
 ]
 
 # --- eidolon abilities (with mp_cost) -----------------------------------------
@@ -357,6 +358,7 @@ MERGED_CLASS_ABILITIES: List[Tuple[int, int, int]] = [
     (3, 43, 20),
     (3, 49, 20),
     (7, 108, 18),
+    (13, 207, 3),
     (9, 24, 20)
 ]
 


### PR DESCRIPTION
### Motivation
- Provide a Beast Master class ability to heal every tamed beast the player owns (including non-active ones) by a percentage or fully restore them.
- Make the ability usable both in-battle and out-of-battle while consuming a turn / respecting cooldowns and MP cost. 
- Reuse existing beast stat calculations so heals are applied relative to each beast’s `max_hp`.

### Description
- Seeded a new ability `Beast Mend` in `database/database_setup.py` with effect key `"heal_all_beasts_pct"` and linked it to the Beast Master class. 
- Added a helper method `._heal_all_beasts(session_id, player_id, heal_pct)` to `game/battle_system.py` that iterates unlocked beasts and updates each via `SessionPlayerModel.update_beast_hp_mp`.
- Wired handling in the skill flow to detect `heal_all_beasts_pct`, consume MP when required, call `._heal_all_beasts`, and append appropriate game log or refresh the room/battle UI for in/out-of-battle cases. 
- Ensured the ability respects full-restore when `heal_pct >= 1.0`, applies a minimum heal for KO beasts when configured, and preserves cooldown/turn advancement.

### Testing
- No automated tests were executed for this change. 
- Code changes were committed and basic integration points (seed, helper method, and skill handler) were exercised during development but no CI/unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cace7183c83289672a0d28d4a57b3)