### PR TITLE
Fix use item target routing

### DIFF
--- a/game/inventory_shop.py
+++ b/game/inventory_shop.py
@@ -202,6 +202,14 @@ class InventoryShop(commands.Cog):
                     pass
                 await self.process_sale(interaction, int(vid), int(iid))
             # --------------- Use-item flow --------------
+            elif cid.startswith("use_item_target_"):
+                parts = cid.split("_", 4)
+                if len(parts) >= 5:
+                    item_id = int(parts[3])
+                    target = parts[4]
+                    await self.process_use_item(interaction, item_id, target=target, prompt_for_target=False)
+                else:
+                    await self.display_use_item_menu(interaction)
             elif cid.startswith("use_item_"):
                 parts = cid.split("_")
                 if len(parts) >= 3:
@@ -212,14 +220,6 @@ class InventoryShop(commands.Cog):
                     except discord.errors.HTTPException:
                         pass
                     await self.process_use_item(interaction, iid)
-                else:
-                    await self.display_use_item_menu(interaction)
-            elif cid.startswith("use_item_target_"):
-                parts = cid.split("_", 4)
-                if len(parts) >= 5:
-                    item_id = int(parts[3])
-                    target = parts[4]
-                    await self.process_use_item(interaction, item_id, target=target, prompt_for_target=False)
                 else:
                     await self.display_use_item_menu(interaction)
             elif cid == "back_from_use":


### PR DESCRIPTION
### Motivation
- The interaction handler matched the generic `use_item_` prefix before the more specific `use_item_target_`, causing the handler to mis-parse target payloads. 
- That mis-parsing produced errors when applying items (e.g., potions) to the player or summoned beasts during battle. 

### Description
- Reordered the interaction routing to handle `use_item_target_` before `use_item_` to ensure target-specific buttons are parsed correctly. 
- Preserved existing parsing and dispatch logic while avoiding incorrect `split`/`int` conversions for target strings. 
- Change applied in `game/inventory_shop.py` only. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ba95f155083289464ee3d128730f0)